### PR TITLE
Upgrade entity_id to UInt64

### DIFF
--- a/src/rosegold/packets/clientbound/destroy_entities.cr
+++ b/src/rosegold/packets/clientbound/destroy_entities.cr
@@ -2,15 +2,15 @@ class Rosegold::Clientbound::DestroyEntities < Rosegold::Clientbound::Packet
   class_getter packet_id = 0x3A_u8
   class_getter state = Rosegold::ProtocolState::PLAY
 
-  property entity_ids : Array(UInt32)
+  property entity_ids : Array(UInt64)
 
   def initialize(@entity_ids)
   end
 
   def self.read(packet)
-    entity_ids = [] of UInt32
+    entity_ids = [] of UInt64
     count = packet.read_var_int
-    count.times { entity_ids << packet.read_var_int }
+    count.times { entity_ids << packet.read_var_long }
     self.new entity_ids
   end
 

--- a/src/rosegold/packets/clientbound/entity_position.cr
+++ b/src/rosegold/packets/clientbound/entity_position.cr
@@ -2,7 +2,7 @@ class Rosegold::Clientbound::EntityPosition < Rosegold::Clientbound::Packet
   class_getter packet_id = 0x29_u8
 
   property \
-    entity_id : UInt32,
+    entity_id : UInt64,
     delta_x : Int16,
     delta_y : Int16,
     delta_z : Int16
@@ -14,7 +14,7 @@ class Rosegold::Clientbound::EntityPosition < Rosegold::Clientbound::Packet
   end
 
   def self.read(packet)
-    entity_id = packet.read_var_int
+    entity_id = packet.read_var_long
     delta_x = packet.read_short
     delta_y = packet.read_short
     delta_z = packet.read_short

--- a/src/rosegold/packets/clientbound/entity_position_and_rotation.cr
+++ b/src/rosegold/packets/clientbound/entity_position_and_rotation.cr
@@ -2,7 +2,7 @@ class Rosegold::Clientbound::EntityPositionAndRotation < Rosegold::Clientbound::
   class_getter packet_id = 0x2A_u8
 
   property \
-    entity_id : UInt32,
+    entity_id : UInt64,
     delta_x : Int16,
     delta_y : Int16,
     delta_z : Int16,
@@ -16,7 +16,7 @@ class Rosegold::Clientbound::EntityPositionAndRotation < Rosegold::Clientbound::
   end
 
   def self.read(packet)
-    entity_id = packet.read_var_int
+    entity_id = packet.read_var_long
     delta_x = packet.read_short
     delta_y = packet.read_short
     delta_z = packet.read_short

--- a/src/rosegold/packets/clientbound/entity_rotation.cr
+++ b/src/rosegold/packets/clientbound/entity_rotation.cr
@@ -2,7 +2,7 @@ class Rosegold::Clientbound::EntityRotation < Rosegold::Clientbound::Packet
   class_getter packet_id = 0x2B_u8
 
   property \
-    entity_id : UInt32,
+    entity_id : UInt64,
     yaw : Float32,
     pitch : Float32
 
@@ -13,7 +13,7 @@ class Rosegold::Clientbound::EntityRotation < Rosegold::Clientbound::Packet
   end
 
   def self.read(packet)
-    entity_id = packet.read_var_int
+    entity_id = packet.read_var_long
     yaw = packet.read_angle256_deg
     pitch = packet.read_angle256_deg
     on_ground = packet.read_bool

--- a/src/rosegold/packets/clientbound/entity_teleport.cr
+++ b/src/rosegold/packets/clientbound/entity_teleport.cr
@@ -6,7 +6,7 @@ class Rosegold::Clientbound::EntityTeleport < Rosegold::Clientbound::Packet
   class_getter packet_id = 0x62_u8
 
   property \
-    entity_id : Int32,
+    entity_id : UInt64,
     location : Vec3d,
     look : Look
   property? \
@@ -16,7 +16,7 @@ class Rosegold::Clientbound::EntityTeleport < Rosegold::Clientbound::Packet
 
   def self.read(packet)
     self.new(
-      packet.read_var_int.to_i32,
+      packet.read_var_long,
       Vec3d.new(
         packet.read_double,
         packet.read_double,

--- a/src/rosegold/packets/clientbound/set_passengers.cr
+++ b/src/rosegold/packets/clientbound/set_passengers.cr
@@ -2,16 +2,16 @@ class Rosegold::Clientbound::SetPassengers < Rosegold::Clientbound::Packet
   class_getter packet_id = 0x54_u8
 
   property \
-    entity_id : UInt32,
-    passengers : Array(UInt32)
+    entity_id : UInt64,
+    passengers : Array(UInt64)
 
   def initialize(@entity_id, @passengers)
   end
 
   def self.read(packet)
-    entity_id = packet.read_var_int
-    passenger_count = packet.read_var_int
-    passengers = passenger_count.times.map { packet.read_var_int }.to_a
+    entity_id = packet.read_var_long
+    passenger_count = packet.read_var_long
+    passengers = passenger_count.times.map { packet.read_var_long }.to_a
 
     self.new(entity_id, passengers)
   end
@@ -22,7 +22,7 @@ class Rosegold::Clientbound::SetPassengers < Rosegold::Clientbound::Packet
       buffer.write entity_id
       buffer.write_var_int(passengers.length)
       passengers.each do |eid|
-        buffer.write_var_int(eid)
+        buffer.write_var_long(eid)
       end
     end.to_slice
   end

--- a/src/rosegold/packets/clientbound/spawn_entity.cr
+++ b/src/rosegold/packets/clientbound/spawn_entity.cr
@@ -2,7 +2,7 @@ class Rosegold::Clientbound::SpawnEntity < Rosegold::Clientbound::Packet
   class_getter packet_id = 0x00_u8
 
   property \
-    entity_id : UInt32,
+    entity_id : UInt64,
     uuid : UUID,
     entity_type : UInt32,
     x : Float64,
@@ -19,7 +19,7 @@ class Rosegold::Clientbound::SpawnEntity < Rosegold::Clientbound::Packet
   end
 
   def self.read(packet)
-    entity_id = packet.read_var_int
+    entity_id = packet.read_var_long
     uuid = packet.read_uuid
     entity_type = packet.read_var_int
     x = packet.read_double

--- a/src/rosegold/packets/clientbound/spawn_living_entity.cr
+++ b/src/rosegold/packets/clientbound/spawn_living_entity.cr
@@ -3,7 +3,7 @@ class Rosegold::Clientbound::SpawnLivingEntity < Rosegold::Clientbound::Packet
   class_getter state = Rosegold::ProtocolState::PLAY
 
   property \
-    entity_id : UInt32,
+    entity_id : UInt64,
     uuid : UUID,
     entity_type : UInt32,
     x : Float64,
@@ -20,7 +20,7 @@ class Rosegold::Clientbound::SpawnLivingEntity < Rosegold::Clientbound::Packet
   end
 
   def self.read(packet)
-    entity_id = packet.read_var_int
+    entity_id = packet.read_var_long
     uuid = packet.read_uuid
     entity_type = packet.read_var_int
     x = packet.read_double

--- a/src/rosegold/packets/clientbound/spawn_player.cr
+++ b/src/rosegold/packets/clientbound/spawn_player.cr
@@ -4,7 +4,7 @@ class Rosegold::Clientbound::SpawnPlayer < Rosegold::Clientbound::Packet
   class_getter packet_id = 0x04_u8
 
   property \
-    entity_id : UInt32,
+    entity_id : UInt64,
     uuid : UUID,
     location : Vec3d,
     look : Look
@@ -12,7 +12,7 @@ class Rosegold::Clientbound::SpawnPlayer < Rosegold::Clientbound::Packet
   def initialize(@entity_id, @uuid, @location, @look); end
 
   def self.read(packet)
-    entity_id = packet.read_var_int
+    entity_id = packet.read_var_long
     uuid = packet.read_uuid
     location = Vec3d.new(packet.read_double, packet.read_double, packet.read_double)
     look = Look.new(yaw: packet.read_angle256_deg, pitch: packet.read_angle256_deg)

--- a/src/rosegold/packets/serverbound/entity_action.cr
+++ b/src/rosegold/packets/serverbound/entity_action.cr
@@ -14,7 +14,7 @@ class Rosegold::Serverbound::EntityAction < Rosegold::Serverbound::Packet
   end
 
   property \
-    entity_id : Int32,
+    entity_id : UInt64,
     action : Type,
     jump_boost : UInt8
 

--- a/src/rosegold/packets/serverbound/interact_entity.cr
+++ b/src/rosegold/packets/serverbound/interact_entity.cr
@@ -8,7 +8,7 @@ class Rosegold::Serverbound::InteractEntity < Rosegold::Serverbound::Packet
   end
 
   property \
-    entity_id : UInt32,
+    entity_id : UInt64,
     action : Action,
     target_x : Float32? = nil,
     target_y : Float32? = nil,
@@ -18,7 +18,7 @@ class Rosegold::Serverbound::InteractEntity < Rosegold::Serverbound::Packet
     sneaking : Bool = false
 
   def initialize(
-    @entity_id : UInt32,
+    @entity_id : UInt64,
     @action : Action,
     @target_x : Float32? = nil,
     @target_y : Float32? = nil,

--- a/src/rosegold/world/dimension.cr
+++ b/src/rosegold/world/dimension.cr
@@ -11,7 +11,7 @@ class Rosegold::Dimension
   getter min_y = -64
   getter world_height = 256 + 64 + 64
 
-  property entities : Hash(UInt32, Entity) = Hash(UInt32, Entity).new
+  property entities : Hash(UInt64, Entity) = Hash(UInt64, Entity).new
 
   def initialize(@name, @nbt)
     @min_y = @nbt["min_y"].as_i32

--- a/src/rosegold/world/entity.cr
+++ b/src/rosegold/world/entity.cr
@@ -17,7 +17,7 @@ class Rosegold::Entity
   end
 
   property \
-    entity_id : UInt32,
+    entity_id : UInt64,
     uuid : UUID,
     entity_type : UInt32,
     position : Vec3d,
@@ -25,7 +25,7 @@ class Rosegold::Entity
     yaw : Float32,
     head_yaw : Float32,
     velocity : Vec3d,
-    passenger_ids : Array(UInt32) = [] of UInt32
+    passenger_ids : Array(UInt64) = [] of UInt64
 
   property? \
     on_ground : Bool = true

--- a/src/rosegold/world/entity.cr
+++ b/src/rosegold/world/entity.cr
@@ -59,8 +59,10 @@ class Rosegold::Entity
     passenger_ids.each do |passenger_id|
       if client.player.entity_id == passenger_id
         client.player.feet = position
+      elsif entity = client.dimension.entities[passenger_id]?
+        entity.position = position
       else
-        client.dimension.entities[passenger_id].position = position
+        Log.warn { "Trying to update passenger #{passenger_id} but it doesn't exist in client.dimensions.entities" }
       end
     end
   end


### PR DESCRIPTION
It seems paper uses varlong, especially when it gets late in the server restart

This doesn't seem to have any negative downstream effects and fixes the issues with civmc late in the day