### PR TITLE
Add more intuitive movement API

### DIFF
--- a/spec/integration/movement_spec.cr
+++ b/spec/integration/movement_spec.cr
@@ -23,10 +23,10 @@ Spectator.describe Rosegold::Bot do
         sleep 1 # teleport
 
         bot.move_to 2, 2
-        expect(bot.feet).to eq(Rosegold::Vec3d.new(2, -60, 2))
+        expect(bot.feet).to eq(Rosegold::Vec3d.new(2.5, -60, 2.5))
 
         bot.move_to -1, -1
-        expect(bot.feet).to eq(Rosegold::Vec3d.new(-1, -60, -1))
+        expect(bot.feet).to eq(Rosegold::Vec3d.new(-0.5, -60, -0.5))
       end
     end
   end

--- a/src/rosegold/bot.cr
+++ b/src/rosegold/bot.cr
@@ -121,8 +121,12 @@ class Rosegold::Bot
 
   # Moves straight towards `location`.
   # Waits for arrival.
-  def move_to(x : Float64, z : Float64)
+  def move_to(x : Float, z : Float)
     client.physics.move Vec3d.new x, feet.y, z
+  end
+
+  def move_to(x : Int, y : Int)
+    move_to x + 0.5, y + 0.5
   end
 
   # Computes the destination location from the current feet location.


### PR DESCRIPTION
Blocks in minecraft are offset by 0.5 but we rarely care about
going to the corners of blocks

Move Bot#move_to(Int, Int) that offsets the grid properly, but still allows
users to pass in floats to get to exact places on blocks elegantly
