### PR TITLE
Save from aabb arguement error

### DIFF
--- a/src/rosegold/world/aabb.cr
+++ b/src/rosegold/world/aabb.cr
@@ -75,6 +75,8 @@ module Rosegold::AABB(T, V)
     return nil if t_far < 0
 
     t_near
+  rescue e : ArgumentError
+    nil
   end
 
   def [](i) : V


### PR DESCRIPTION
Happens sometimes when the math doesn't jive
Instead of fatally dying, just simply return nil

Possibly resolves #165
