### PR TITLE
Throw all items when using Inventory#throw_all_items

### DIFF
--- a/spec/integration/inventory_spec.cr
+++ b/spec/integration/inventory_spec.cr
@@ -245,4 +245,27 @@ Spectator.describe Rosegold::Bot do
       end
     end
   end
+
+  describe "#throw_all_of" do
+    it "throws all of the specified item" do
+      client.join_game do |client|
+        Rosegold::Bot.new(client).try do |bot|
+          bot.chat "/clear"
+          bot.chat "/give #{bot.username} minecraft:diamond_sword 4"
+          bot.chat "/give #{bot.username} minecraft:stone 200"
+          sleep 1
+
+          expect(bot.inventory.throw_all_of "diamond_sword").to eq 4
+          expect(bot.inventory.throw_all_of "stone").to eq 200
+
+          sleep 1
+
+          expect(bot.inventory.inventory.map(&.item_id)).not_to contain "diamond_sword"
+          expect(bot.inventory.hotbar.map(&.item_id)).not_to contain "diamond_sword"
+          expect(bot.inventory.inventory.map(&.item_id)).not_to contain "stone"
+          expect(bot.inventory.hotbar.map(&.item_id)).not_to contain "stone"
+        end
+      end
+    end
+  end
 end

--- a/src/rosegold/control/inventory.cr
+++ b/src/rosegold/control/inventory.cr
@@ -97,11 +97,15 @@ class Rosegold::Inventory
   end
 
   def throw_all_of(item_id)
+    quantity = 0
     slots.each do |slot|
       next unless slot.item_id == item_id
+      quantity += slot.count
 
-      client.send_packet! Serverbound::ClickWindow.new :drop, 0_i8, slot.slot_number.to_i16, [] of WindowSlot, client.window.id.to_u8, client.window.state_id.to_i32, client.window.cursor
+      client.send_packet! Serverbound::ClickWindow.new :drop, 1_i8, slot.slot_number.to_i16, [] of WindowSlot, client.window.id.to_u8, client.window.state_id.to_i32, client.window.cursor
     end
+
+    quantity
   end
 
   private def shift_click_at_least(count, spec, source : Array(WindowSlot), target : Array(WindowSlot))


### PR DESCRIPTION
Previously just threw 1 off of each stack in the inventory
Now it uses the equal to pressing control+drop on the vanilla
client

Also return the count dropped
