### PR TITLE
Fix continuous digging and improve digging spec

### DIFF
--- a/spec/fixtures/server/ops.json
+++ b/spec/fixtures/server/ops.json
@@ -10,5 +10,11 @@
     "name": "rosegoldtest",
     "level": 4,
     "bypassesPlayerLimit": false
+  },
+  {
+    "uuid": "810bc3ed-7c1a-3dcd-9adc-383cfd922e7f",
+    "name": "grepsedawk",
+    "level": 4,
+    "bypassesPlayerLimit": false
   }
 ]

--- a/src/rosegold/control/interactions.cr
+++ b/src/rosegold/control/interactions.cr
@@ -245,9 +245,9 @@ class Rosegold::Interactions
     reached = @digging_block
     return unless reached
 
-    # Reset digging state
+    # Reset digging block but keep digging state for continuous digging
     @digging_block = nil
-    self.digging = false
+    # Don't set self.digging = false here to allow continuous digging
 
     # Generate sequence number for MC 1.21+
     sequence = client.protocol_version >= 767_u32 ? client.next_sequence : 0


### PR DESCRIPTION
- Allow bots to dig through multiple blocks continuously by not stopping digging state after each block
- Combine single and continuous digging specs into one comprehensive test
- Replace fixed wait times with smart waiting based on bot position with timeout
- Reduce test blocks from 10 to 3 for faster test execution
- Add grepsedawk to server ops for testing

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
