### PR TITLE
Fix not being able to call bot.disconnect

### DIFF
--- a/src/rosegold/client.cr
+++ b/src/rosegold/client.cr
@@ -23,6 +23,8 @@ class Rosegold::Client < Rosegold::EventEmitter
   property detected_protocol_version : UInt32?
   property current_protocol_state : ProtocolState = ProtocolState::HANDSHAKING
 
+  delegate disconnect, to: connection
+
   property \
     player : Player = Player.new,
     access_token : String = "",


### PR DESCRIPTION
Rosegold::Bot delegated disconnect to Rosegold::Client, but Client does not have that method, Rosegold::Connection does.