### PR TITLE
Replace action cancellation with graceful handling

### DIFF
--- a/src/rosegold/control/action.cr
+++ b/src/rosegold/control/action.cr
@@ -16,7 +16,10 @@ class Rosegold::Action(T)
     @channel.send exception
   end
 
-  # Throw error if it failed
+  def cancel
+    @channel.send nil
+  end
+
   def join
     result = channel.receive
     raise result if result


### PR DESCRIPTION
Add Action#cancel method that sends nil (like succeed) instead of exceptions.
Extract replace_movement_action and replace_look_action helper methods to
eliminate repetitive mutex synchronization code. This prevents "Replaced by..."
exceptions from crashing scripts when setting new movement/look targets.
