### PR TITLE
Fix code formatting

### DIFF
--- a/spec/integration/inventory_spec.cr
+++ b/spec/integration/inventory_spec.cr
@@ -313,7 +313,7 @@ Spectator.describe "Rosegold::Bot inventory" do
 
             initial_count = bot.inventory.count("stone", bot.inventory.inventory + bot.inventory.hotbar)
             result = bot.inventory.replenish 5, "stone"
-            
+
             expect(result).to be > initial_count
           end
         end


### PR DESCRIPTION
Remove trailing whitespace from inventory spec to comply with Crystal formatting standards.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
