### PR TITLE
Fix window inventory desync from late packets

### DIFF
--- a/src/rosegold/chat_manager.cr
+++ b/src/rosegold/chat_manager.cr
@@ -79,7 +79,7 @@ class Rosegold::ChatManager
       client.send_packet!(packet)
       true
     rescue e : Exception
-      Log.error { "Failed to send chat command: #{e}" }
+      Log.error { "Failed to send chat command (#{e.class} - #{e.message}): #{command}" }
       false
     end
   end

--- a/src/rosegold/packets/clientbound/open_window.cr
+++ b/src/rosegold/packets/clientbound/open_window.cr
@@ -110,6 +110,8 @@ class Rosegold::Clientbound::OpenWindow < Rosegold::Clientbound::Packet
   def callback(client)
     # Clamp window_id to valid UInt8 range
     clamped_id = window_id > 255 ? 255_u8 : window_id.to_u8
+    # Clear previous window ID when opening a new window
+    client.inventory.previous_window_id = nil
     client.window = Window.new \
       client, clamped_id, window_title, window_type
     Log.debug { "Server opened window id=#{window_id} type=#{window_type} title: #{window_title}" }

--- a/src/rosegold/packets/clientbound/set_container_content.cr
+++ b/src/rosegold/packets/clientbound/set_container_content.cr
@@ -53,8 +53,11 @@ class Rosegold::Clientbound::SetContainerContent < Rosegold::Clientbound::Packet
       client.window.state_id = state_id
       client.window.slots = slots
       client.window.cursor = cursor
+    elsif client.inventory.previous_window_id && client.inventory.previous_window_id == window_id
+      # Handle late container content packet using shared method
+      client.inventory.handle_late_packet(window_id.to_u8, slots: slots, cursor: cursor, state_id: state_id)
     else
-      Log.warn { "Received container content for an unknown or mismatched window. Ignoring." }
+      Log.warn { "Received container content for an unknown or mismatched window. Ignoring. Packet window_id=#{window_id}, client window_id=#{client.window.id}, previous_window_id=#{client.inventory.previous_window_id}" }
       Log.debug { self }
     end
   end

--- a/src/rosegold/packets/clientbound/set_slot.cr
+++ b/src/rosegold/packets/clientbound/set_slot.cr
@@ -39,8 +39,11 @@ class Rosegold::Clientbound::SetSlot < Rosegold::Clientbound::Packet
       client.inventory.slots[slot.slot_number] = slot
     elsif client.window.id == window_id
       client.window.slots[slot.slot_number] = slot
+    elsif client.inventory.previous_window_id && client.inventory.previous_window_id == window_id.to_u8
+      # Handle late slot update packet using shared method
+      client.inventory.handle_late_packet(window_id.to_u8, slot: slot)
     else
-      Log.warn { "Received slot update for an unknown or mismatched window. Ignoring." }
+      Log.warn { "Received slot update for an unknown or mismatched window. Ignoring. Packet window_id=#{window_id}, client window_id=#{client.window.id}, previous_window_id=#{client.inventory.previous_window_id}, slot=#{slot}" }
       Log.debug { self }
     end
   end


### PR DESCRIPTION
Prevents SetContainerContent and SetSlot packets that arrive after
Window#handle_closed from causing inventory desync and warnings.
Adds support for handling late packets from one previous window ID
by temporarily recreating the window and properly closing it.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
