### PR TITLE
Add support for slot content data type 35 (DyedColor)

### DIFF
--- a/spec/integration/bed_spec.cr
+++ b/spec/integration/bed_spec.cr
@@ -30,16 +30,10 @@ Spectator.describe "Rosegold::Bot bed interactions" do
         bot.chat "/tp 0.5 -60 0.5"
         bot.wait_tick
 
-        # Record initial position
-        initial_position = bot.feet
-
         # Interact with the bed to get in (look down at the bed)
         bot.look_at Rosegold::Vec3d.new(0.5, -60.5, 0.5)
         bot.use_hand
         bot.wait_ticks 5 # Wait for bed interaction to process
-
-        # Position may have changed when sleeping
-        sleeping_position = bot.feet
 
         # Get out of bed using the leave_bed method
         bot.leave_bed
@@ -106,16 +100,10 @@ Spectator.describe "Rosegold::Bot bed interactions" do
         bot.chat "/tp 3.5 -60 0.5"
         bot.wait_tick
 
-        # Record initial position
-        initial_position = bot.feet
-
         # Interact with the bed at night
         bot.look_at Rosegold::Vec3d.new(3.5, -60.5, 0.5)
         bot.use_hand
         bot.wait_ticks 5 # Wait for bed interaction to process
-
-        # Position may have changed if sleeping was successful
-        sleeping_position = bot.feet
 
         # Wake up using leave_bed method
         bot.leave_bed

--- a/spec/packets/clientbound/set_container_content_spec.cr
+++ b/spec/packets/clientbound/set_container_content_spec.cr
@@ -84,5 +84,14 @@ Spectator.describe Rosegold::Clientbound::SetContainerContent do
         expect { Rosegold::Clientbound::SetContainerContent.read(io) }.not_to raise_error(Exception, /Unknown data component type: 15/)
       end
     end
+
+    describe "includes dyed_color data component type 35" do
+      let(:failing_packet_hex) { "12002e2e00000000000000000194070600050a0100066974616c696300080005636f6c6f720004676f6c6408000474657874001a5061726b6f757220436976696c697a6174696f6e20426f6f74730008010a0100066974616c69630008000474657874002155736520746865736520746f206265636f6d652061205061726b6f75722050726f000a060201070309041b06270528010f00020a2f2f0a1223009d9d970000000000000000000000000000000000000000000000000000000000000000000000319b0900000000" }
+
+      it "is able to read" do
+        io.read_byte # Skip packet ID (0x12)
+        expect { Rosegold::Clientbound::SetContainerContent.read(io) }.not_to raise_error
+      end
+    end
   end
 end

--- a/src/rosegold/world/slot.cr
+++ b/src/rosegold/world/slot.cr
@@ -144,6 +144,8 @@ abstract class Rosegold::DataComponent
       DataComponents::CreativeSlotLock.read(io)
     when 18 # minecraft:enchantment_glint_override - Boolean
       DataComponents::EnchantmentGlintOverride.read(io)
+    when 35 # minecraft:dyed_color - Color of dyed leather armor
+      DataComponents::DyedColor.read(io)
     when 36 # minecraft:map_color - Int
       DataComponents::MapColor.read(io)
     when 37 # minecraft:map_id - The ID of the map (VarInt)


### PR DESCRIPTION
## Summary
• Implements the missing `minecraft:dyed_color` data component (type 35)
• Fixes packet parsing errors when encountering containers with dyed leather armor
• Adds proper RGB color storage for dyed items
• Fixes unrelated linter warnings in bed_spec.cr

## Test plan
- [x] Added spec test case using the failing packet bytes
- [x] Verified packet can now be parsed without errors
- [x] All existing tests continue to pass
- [x] Linter passes without warnings

🤖 Generated with [Claude Code](https://claude.ai/code)