### PR TITLE
movement keys

### DIFF
--- a/spec/integration/movement_keys_spec.cr
+++ b/spec/integration/movement_keys_spec.cr
@@ -1,0 +1,133 @@
+require "../spec_helper"
+
+Spectator.describe "Rosegold::Bot movement keys" do
+  before_all do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        bot.chat "/kill @e[type=!minecraft:player]"
+        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
+        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
+        bot.wait_tick
+      end
+    end
+  end
+
+  it "moves forward when forward key is pressed" do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        bot.chat "/tp 0 -60 0"
+        bot.wait_tick
+
+        bot.yaw = 0.0 # face south (+Z)
+        initial_z = bot.location.z
+
+        bot.keys.press Rosegold::MovementKeys::Key::Forward
+        bot.wait_ticks 10
+        bot.keys.release_all
+
+        expect(bot.location.z).to be > initial_z
+      end
+    end
+  end
+
+  it "moves backward when backward key is pressed" do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        bot.chat "/tp 0 -60 0"
+        bot.wait_tick
+
+        bot.yaw = 0.0 # face south (+Z)
+        initial_z = bot.location.z
+
+        bot.keys.press Rosegold::MovementKeys::Key::Backward
+        bot.wait_ticks 10
+        bot.keys.release_all
+
+        expect(bot.location.z).to be < initial_z
+      end
+    end
+  end
+
+  it "strafes left when left key is pressed" do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        bot.chat "/tp 0 -60 0"
+        bot.wait_tick
+
+        bot.yaw = 0.0 # face south (+Z), left is +X
+        initial_x = bot.location.x
+
+        bot.keys.press Rosegold::MovementKeys::Key::Left
+        bot.wait_ticks 10
+        bot.keys.release_all
+
+        expect(bot.location.x).to be > initial_x
+      end
+    end
+  end
+
+  it "moves diagonally with two keys pressed" do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        bot.chat "/tp 0 -60 0"
+        bot.wait_tick
+
+        bot.yaw = 0.0 # face south
+        initial = bot.location
+
+        bot.keys.press Rosegold::MovementKeys::Key::Forward | Rosegold::MovementKeys::Key::Left
+        bot.wait_ticks 10
+        bot.keys.release_all
+
+        expect(bot.location.z).to be > initial.z
+        expect(bot.location.x).to be > initial.x
+      end
+    end
+  end
+
+  it "stops moving after release_all" do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        bot.chat "/tp 0 -60 0"
+        bot.wait_tick
+
+        bot.yaw = 0.0
+        bot.keys.press Rosegold::MovementKeys::Key::Forward
+        bot.wait_ticks 10
+        bot.keys.release_all
+
+        # Wait for velocity to decay
+        bot.wait_ticks 10
+        settled = bot.location
+
+        bot.wait_ticks 5
+        expect(bot.location.z).to be_close(settled.z, 0.01)
+      end
+    end
+  end
+
+  it "move_to clears movement keys on completion" do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        bot.chat "/tp 0 -60 0"
+        bot.wait_tick
+
+        bot.keys.press Rosegold::MovementKeys::Key::Left
+        bot.move_to 2, 2
+
+        expect(bot.keys.none?).to be_true
+      end
+    end
+  end
+
+  it "stop_moving clears movement keys" do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        bot.keys.press Rosegold::MovementKeys::Key::Forward | Rosegold::MovementKeys::Key::Right
+        bot.stop_moving
+
+        expect(bot.keys.none?).to be_true
+      end
+    end
+  end
+end

--- a/spec/models/movement_keys_spec.cr
+++ b/spec/models/movement_keys_spec.cr
@@ -1,0 +1,87 @@
+require "../spec_helper"
+
+Spectator.describe Rosegold::MovementKeys do
+  let(keys) { Rosegold::MovementKeys.new }
+
+  describe "#press" do
+    it "sets a single key" do
+      keys.press Rosegold::MovementKeys::Key::Forward
+      expect(keys.forward?).to be_true
+      expect(keys.backward?).to be_false
+    end
+
+    it "sets multiple keys with bitwise OR" do
+      keys.press Rosegold::MovementKeys::Key::Forward | Rosegold::MovementKeys::Key::Left
+      expect(keys.forward?).to be_true
+      expect(keys.left?).to be_true
+      expect(keys.right?).to be_false
+    end
+
+    it "sets multiple keys with splat" do
+      keys.press Rosegold::MovementKeys::Key::Forward, Rosegold::MovementKeys::Key::Left
+      expect(keys.forward?).to be_true
+      expect(keys.left?).to be_true
+      expect(keys.right?).to be_false
+    end
+
+    it "adds to existing keys" do
+      keys.press Rosegold::MovementKeys::Key::Forward
+      keys.press Rosegold::MovementKeys::Key::Left
+      expect(keys.forward?).to be_true
+      expect(keys.left?).to be_true
+    end
+  end
+
+  describe "#release" do
+    it "clears a single key" do
+      keys.press Rosegold::MovementKeys::Key::Forward, Rosegold::MovementKeys::Key::Left
+      keys.release Rosegold::MovementKeys::Key::Forward
+      expect(keys.forward?).to be_false
+      expect(keys.left?).to be_true
+    end
+
+    it "clears multiple keys with splat" do
+      keys.press Rosegold::MovementKeys::Key::Forward, Rosegold::MovementKeys::Key::Left, Rosegold::MovementKeys::Key::Right
+      keys.release Rosegold::MovementKeys::Key::Forward, Rosegold::MovementKeys::Key::Left
+      expect(keys.forward?).to be_false
+      expect(keys.left?).to be_false
+      expect(keys.right?).to be_true
+    end
+
+    it "is a no-op for already released keys" do
+      keys.release Rosegold::MovementKeys::Key::Forward
+      expect(keys.forward?).to be_false
+    end
+  end
+
+  describe "#release_all" do
+    it "clears all keys" do
+      keys.press Rosegold::MovementKeys::Key::Forward | Rosegold::MovementKeys::Key::Left | Rosegold::MovementKeys::Key::Right
+      keys.release_all
+      expect(keys.none?).to be_true
+    end
+  end
+
+  describe "#pressed?" do
+    it "returns true when key is pressed" do
+      keys.press Rosegold::MovementKeys::Key::Forward
+      expect(keys.pressed?(Rosegold::MovementKeys::Key::Forward)).to be_true
+    end
+
+    it "returns false when key is not pressed" do
+      expect(keys.pressed?(Rosegold::MovementKeys::Key::Forward)).to be_false
+    end
+
+    it "checks all specified keys are pressed" do
+      keys.press Rosegold::MovementKeys::Key::Forward
+      expect(keys.pressed?(Rosegold::MovementKeys::Key::Forward | Rosegold::MovementKeys::Key::Left)).to be_false
+
+      keys.press Rosegold::MovementKeys::Key::Left
+      expect(keys.pressed?(Rosegold::MovementKeys::Key::Forward | Rosegold::MovementKeys::Key::Left)).to be_true
+    end
+  end
+
+  it "starts with no keys pressed" do
+    expect(keys.none?).to be_true
+  end
+end

--- a/src/rosegold/bot.cr
+++ b/src/rosegold/bot.cr
@@ -128,6 +128,10 @@ class Rosegold::Bot < Rosegold::EventEmitter
     look_at location.with_y eyes.y
   end
 
+  def keys
+    client.physics.keys
+  end
+
   # Moves straight towards `location`.
   # Waits for arrival.
   # `stuck_timeout_ticks` specifies how many consecutive stuck ticks before throwing MovementStuck.
@@ -159,9 +163,9 @@ class Rosegold::Bot < Rosegold::EventEmitter
   end
 
   # Stop moving towards the target specified in #move_to
-  # Dequeue any jump queued with #start_jump
+  # Also releases all movement keys and dequeues any pending jump.
   def stop_moving
-    client.physics.move = nil
+    client.physics.stop_moving
     client.physics.jump_queued = false
   end
 

--- a/src/rosegold/control/action.cr
+++ b/src/rosegold/control/action.cr
@@ -1,22 +1,29 @@
 class Rosegold::Action(T)
   getter channel : Channel(Exception | Nil) = Channel(Exception | Nil).new
   getter target : T
+  @done = false
 
   def initialize(@target : T); end
 
   def succeed
+    return if @done
+    @done = true
     @channel.send nil
   end
 
   def fail(msg : String)
-    @channel.send Exception.new msg
+    fail Exception.new msg
   end
 
   def fail(exception : Exception)
+    return if @done
+    @done = true
     @channel.send exception
   end
 
   def cancel
+    return if @done
+    @done = true
     @channel.send nil
   end
 

--- a/src/rosegold/control/movement_keys.cr
+++ b/src/rosegold/control/movement_keys.cr
@@ -1,0 +1,29 @@
+class Rosegold::MovementKeys
+  @[Flags]
+  enum Key
+    Forward
+    Backward
+    Left
+    Right
+  end
+
+  property state : Key = Key::None
+
+  def press(*keys : Key)
+    keys.each { |k| @state |= k }
+  end
+
+  def release(*keys : Key)
+    keys.each { |k| @state &= ~k }
+  end
+
+  def release_all
+    @state = Key::None
+  end
+
+  def pressed?(keys : Key) : Bool
+    state.includes? keys
+  end
+
+  delegate forward?, backward?, left?, right?, none?, to: state
+end

--- a/src/rosegold/control/physics.cr
+++ b/src/rosegold/control/physics.cr
@@ -60,6 +60,7 @@ class Rosegold::Physics
   private getter client : Rosegold::Client
   property? paused : Bool = true
   property? jump_queued : Bool = false
+  getter keys : MovementKeys = MovementKeys.new
   private getter movement_action : Action(Vec3d)?
   private getter look_action : Action(Look)?
   private getter action_mutex : Mutex = Mutex.new
@@ -143,9 +144,8 @@ class Rosegold::Physics
 
   def handle_disconnect
     @paused = true
-    @movement_action.try &.fail Client::NotConnected.new "Disconnected from server"
-    @movement_action = nil
-    @look_action.try &.fail Rosegold::Client::NotConnected.new "Disconnected from server"
+    stop_moving
+    @look_action.try &.cancel
     @look_action = nil
   end
 
@@ -176,6 +176,11 @@ class Rosegold::Physics
     @last_position = nil
     @current_stuck_timeout_ticks = stuck_timeout_ticks
     action.join
+  end
+
+  def stop_moving
+    replace_movement_action(nil)
+    keys.release_all
   end
 
   def sneak(sneaking = true)
@@ -248,10 +253,10 @@ class Rosegold::Physics
     client.dimension
   end
 
-  def tick(virtual_input : Rosegold::VirtualInput? = nil)
+  def tick
     return if paused? || !client.connected?
 
-    input = virtual_input || convert_movement_goals_to_input
+    input = convert_movement_goals_to_input
     process_virtual_input(input)
 
     movement, next_velocity, new_feet, on_ground = execute_movement_physics
@@ -274,16 +279,15 @@ class Rosegold::Physics
   private def convert_movement_goals_to_input : Rosegold::VirtualInput
     curr_movement = @movement_action
 
-    forward = false
-
     if curr_movement
       move_direction = (curr_movement.target - player.feet).with_y(0)
 
+      keys.release_all
       if move_direction.length >= VERY_CLOSE
+        keys.press MovementKeys::Key::Forward
         target_yaw = Math.atan2(-move_direction.x, move_direction.z) * (180.0 / Math::PI)
         target_look = Look.new(target_yaw.to_f32, player.look.pitch)
         player.look = target_look
-        forward = true
       end
     end
 
@@ -292,10 +296,10 @@ class Rosegold::Physics
     sprint = player.sprinting? && !sneak
 
     Rosegold::VirtualInput.new(
-      forward: forward,
-      backward: false,
-      left: false,
-      right: false,
+      forward: keys.forward?,
+      backward: keys.backward?,
+      left: keys.left?,
+      right: keys.right?,
       jump: jump,
       sneak: sneak,
       sprint: sprint
@@ -494,6 +498,7 @@ class Rosegold::Physics
           player.velocity = Vec3d.new(0.0, player.velocity.y, 0.0)
           movement_action.succeed
           @movement_action = nil
+          keys.release_all
         end
       end
 
@@ -510,7 +515,7 @@ class Rosegold::Physics
 
           if @current_stuck_timeout_ticks > 0 && @consecutive_stuck_ticks >= @current_stuck_timeout_ticks
             action.fail MovementStuck.new "Movement stuck for #{@current_stuck_timeout_ticks} consecutive ticks at #{feet}"
-            @movement_action = nil
+            stop_moving
           end
         else
           @consecutive_stuck_ticks = 0


### PR DESCRIPTION
To move backward: `bot.backward_key = true`

When using `bot.move_to`, all movement keys are cleared.