### PR TITLE
Prevent falling off edges when sneaking

### DIFF
--- a/spec/integration/sneak_edge_spec.cr
+++ b/spec/integration/sneak_edge_spec.cr
@@ -1,0 +1,73 @@
+require "../spec_helper"
+
+Spectator.describe "Rosegold::Bot sneak edge prevention" do
+  before_all do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        bot.chat "/kill @e[type=!minecraft:player]"
+        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
+        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
+        bot.wait_tick
+      end
+    end
+  end
+
+  it "should not fall off edge when sneaking" do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        # Build a 1-block pillar with air on all sides at ground level
+        bot.chat "/fill -2 -60 -2 4 -56 4 minecraft:air"
+        bot.chat "/setblock 0 -57 0 minecraft:stone"
+        bot.wait_ticks 3
+        bot.chat "/tp 0 -56 0"
+        bot.wait_tick
+        until client.player.on_ground?
+          bot.wait_tick
+        end
+        expect(client.player.feet.y).to eq(-56.0)
+
+        bot.sneak
+        bot.wait_tick
+
+        # Try to walk off the edge — should get stuck, not fall
+        expect {
+          bot.move_to 2, 0, stuck_timeout_ticks: 20
+        }.to raise_error(Rosegold::Physics::MovementStuck)
+
+        # Player should still be on the block, not fallen
+        expect(client.player.feet.y).to be >= -56.0
+
+        bot.unsneak
+        bot.wait_tick
+      end
+    end
+  end
+
+  it "should fall off edge when not sneaking" do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        # Same setup: 1-block pillar with air around it
+        bot.chat "/fill -2 -60 -2 4 -56 4 minecraft:air"
+        bot.chat "/setblock 0 -57 0 minecraft:stone"
+        bot.wait_ticks 3
+        bot.chat "/tp 0 -56 0"
+        bot.wait_tick
+        until client.player.on_ground?
+          bot.wait_tick
+        end
+
+        initial_y = client.player.feet.y
+
+        # Without sneaking, should walk off and fall
+        begin
+          bot.move_to 2, 0, stuck_timeout_ticks: 40
+        rescue Rosegold::Physics::MovementStuck
+        end
+
+        expect(client.player.feet.y).to be < initial_y
+
+        bot.wait_tick
+      end
+    end
+  end
+end

--- a/spec/models/sneak_edge_spec.cr
+++ b/spec/models/sneak_edge_spec.cr
@@ -1,0 +1,105 @@
+require "../spec_helper"
+require "../../src/rosegold/control/physics"
+require "../../src/rosegold/world/aabb"
+require "../../src/rosegold/world/vec3"
+
+Spectator.describe "Sneak edge prevention (maybeBackOffFromEdge)" do
+  # Platform: 3x1x3 blocks at y=0..1, x=0..3, z=0..3
+  # Player half-width: 0.3 (AABB is 0.6 wide)
+  # Grown obstacles (Minkowski sum) extend 0.3 past block edges
+  # So ground coverage extends to x=3.3 from the x=2 block row
+  #
+  # maybeBackOffFromEdge checks if there's solid ground below the player
+  # after proposed horizontal movement, and clamps movement if not.
+
+  let(sneaking_aabb) { Rosegold::Player::SNEAKING_AABB }
+
+  def raw_platform_blocks : Array(Rosegold::AABBd)
+    blocks = [] of Rosegold::AABBd
+    (0..2).each do |x|
+      (0..2).each do |z_idx|
+        blocks << Rosegold::AABBd.new(x.to_f64, 0.0, z_idx.to_f64, x.to_f64 + 1.0, 1.0, z_idx.to_f64 + 1.0)
+      end
+    end
+    blocks
+  end
+
+  def grown_obstacles(entity_aabb : Rosegold::AABBf) : Array(Rosegold::AABBd)
+    entity_aabb_d = entity_aabb.to_f64
+    grow_aabb = entity_aabb_d * -1
+    raw_platform_blocks.map(&.grow(grow_aabb))
+  end
+
+  # Simulate multiple physics ticks with sneak edge prevention applied.
+  # When sneaking=true, calls Physics.maybe_back_off_from_edge before collision.
+  def simulate_ticks(
+    start : Rosegold::Vec3d,
+    x_velocity : Float64,
+    z_velocity : Float64,
+    entity_aabb : Rosegold::AABBf,
+    ticks : Int32,
+    sneaking : Bool = false,
+  ) : Rosegold::Vec3d
+    obstacles = grown_obstacles(entity_aabb)
+    blocks = raw_platform_blocks
+    pos = start
+    vel_y = -0.08 # gravity
+
+    ticks.times do
+      velocity = Rosegold::Vec3d.new(x_velocity, vel_y, z_velocity)
+
+      if sneaking
+        velocity = Rosegold::Physics.maybe_back_off_from_edge(pos, velocity, entity_aabb) do |test_aabb|
+          blocks.none?(&.intersects?(test_aabb))
+        end
+      end
+
+      movement, new_vel = Rosegold::Physics.predict_movement_collision(pos, velocity, obstacles)
+      pos = pos + movement
+
+      vertical_collided = (movement.y - velocity.y).abs > 1.0e-7
+      if vertical_collided && velocity.y < 0
+        vel_y = -0.08
+      else
+        vel_y = new_vel.y * 0.98 - 0.08
+      end
+    end
+    pos
+  end
+
+  context "without sneaking" do
+    it "player falls off edge after walking past ground coverage" do
+      start = Rosegold::Vec3d.new(1.5, 1.0, 1.5)
+      final_pos = simulate_ticks(start, 0.15, 0.0, sneaking_aabb, 20, sneaking: false)
+      expect(final_pos.y).to be < 1.0
+    end
+  end
+
+  context "with sneaking" do
+    it "player should not fall off edge when walking toward it" do
+      start = Rosegold::Vec3d.new(2.0, 1.0, 1.5)
+      final_pos = simulate_ticks(start, 0.15, 0.0, sneaking_aabb, 20, sneaking: true)
+      expect(final_pos.y).to eq 1.0
+    end
+
+    it "player should not fall off edge diagonally" do
+      start = Rosegold::Vec3d.new(2.0, 1.0, 2.0)
+      final_pos = simulate_ticks(start, 0.1, 0.1, sneaking_aabb, 20, sneaking: true)
+      expect(final_pos.y).to eq 1.0
+    end
+
+    it "player should move freely away from edge when sneaking" do
+      start = Rosegold::Vec3d.new(2.5, 1.0, 1.5)
+      final_pos = simulate_ticks(start, -0.1, 0.0, sneaking_aabb, 2, sneaking: true)
+      expect(final_pos.x).to be < start.x
+      expect(final_pos.y).to be_close(1.0, 0.01)
+    end
+
+    it "player at center of platform should move normally when sneaking" do
+      start = Rosegold::Vec3d.new(1.0, 1.0, 1.5)
+      final_pos = simulate_ticks(start, 0.05, 0.0, sneaking_aabb, 3, sneaking: true)
+      expect(final_pos.x).to be > start.x
+      expect(final_pos.y).to eq 1.0
+    end
+  end
+end

--- a/src/rosegold/control/physics.cr
+++ b/src/rosegold/control/physics.cr
@@ -45,6 +45,8 @@ class Rosegold::Physics
   BLUE_ICE_SLIP = 0.989 # Blue Ice slipperiness (most slippery)
   AIR_SLIP      =   1.0 # Air has no friction
 
+  MAX_UP_STEP = 0.6
+
   VERY_CLOSE = 0.1
 
   # Epsilon constants for floating point precision
@@ -136,6 +138,7 @@ class Rosegold::Physics
 
     player.velocity = Vec3d::ORIGIN
     player.on_ground = false
+    player.fall_distance = 0.0
 
     @last_sent_feet = player.feet
     @last_sent_on_ground = player.on_ground?
@@ -278,6 +281,12 @@ class Rosegold::Physics
     player.feet = new_feet
     player.on_ground = on_ground
 
+    if on_ground
+      player.fall_distance = 0.0
+    elsif movement.y < 0
+      player.fall_distance -= movement.y
+    end
+
     track_stuck_movement(new_feet)
 
     send_input_if_changed(input)
@@ -394,6 +403,7 @@ class Rosegold::Physics
 
   private def execute_movement_physics : {Vec3d, Vec3d, Vec3d, Bool}
     input_velocity = velocity_from_movement_input
+    input_velocity = maybe_back_off_from_edge(input_velocity)
 
     movement, post_collision_velocity = Physics.predict_movement_collision(
       player.feet, input_velocity, current_player_aabb, dimension)
@@ -486,6 +496,116 @@ class Rosegold::Physics
     end
 
     Vec3d.new(combined_velocity.x, vel_y, combined_velocity.z)
+  end
+
+  private def maybe_back_off_from_edge(velocity : Vec3d) : Vec3d
+    return velocity unless player.sneaking?
+    return velocity if player.flying?
+    return velocity if velocity.y > 0.0
+    return velocity unless above_ground?
+
+    entity_aabb = current_player_aabb
+    Physics.maybe_back_off_from_edge(player.feet, velocity, entity_aabb) do |test_aabb|
+      no_collision?(test_aabb)
+    end
+  end
+
+  private def above_ground? : Bool
+    player.on_ground? || (player.fall_distance < MAX_UP_STEP &&
+      !can_fall_at_least?(0.0, 0.0, MAX_UP_STEP - player.fall_distance))
+  end
+
+  private def can_fall_at_least?(dx : Float64, dz : Float64, max_fall_dist : Float64) : Bool
+    test_aabb = Physics.make_fall_test_aabb(
+      player.feet, current_player_aabb.to_f64, dx, dz, max_fall_dist, EPSILON_COLLISION)
+    no_collision?(test_aabb)
+  end
+
+  private def no_collision?(box : AABBd) : Bool
+    min_block = box.min.block
+    max_block = box.max.block
+    block_coords = Indexable.cartesian_product({
+      (min_block.x..max_block.x).to_a,
+      (min_block.y..max_block.y).to_a,
+      (min_block.z..max_block.z).to_a,
+    })
+    block_coords.each do |coords|
+      bx, by, bz = coords
+      block_state = dimension.block_state(bx, by, bz)
+      if block_state
+        shapes = MCData.default.block_state_collision_shapes[block_state]
+        shapes.each do |shape|
+          block_aabb = shape.to_f64.offset(bx.to_f64, by.to_f64, bz.to_f64)
+          return false if box.intersects?(block_aabb)
+        end
+      else
+        return false
+      end
+    end
+    true
+  end
+
+  def self.maybe_back_off_from_edge(
+    feet : Vec3d, velocity : Vec3d, entity_aabb : AABBf,
+    &would_fall : AABBd -> Bool
+  ) : Vec3d
+    x = velocity.x
+    z = velocity.z
+    step = 0.05
+    entity_aabb_d = entity_aabb.to_f64
+    step_x = x.sign * step
+    step_z = z.sign * step
+
+    while x != 0.0
+      test_aabb = make_fall_test_aabb(feet, entity_aabb_d, x, 0.0, MAX_UP_STEP, EPSILON_COLLISION)
+      break unless would_fall.call(test_aabb)
+      if x.abs <= step
+        x = 0.0
+        break
+      end
+      x -= step_x
+    end
+
+    while z != 0.0
+      test_aabb = make_fall_test_aabb(feet, entity_aabb_d, 0.0, z, MAX_UP_STEP, EPSILON_COLLISION)
+      break unless would_fall.call(test_aabb)
+      if z.abs <= step
+        z = 0.0
+        break
+      end
+      z -= step_z
+    end
+
+    while x != 0.0 && z != 0.0
+      test_aabb = make_fall_test_aabb(feet, entity_aabb_d, x, z, MAX_UP_STEP, EPSILON_COLLISION)
+      break unless would_fall.call(test_aabb)
+      if x.abs <= step
+        x = 0.0
+      else
+        x -= step_x
+      end
+      if z.abs <= step
+        z = 0.0
+      else
+        z -= step_z
+      end
+    end
+
+    Vec3d.new(x, velocity.y, z)
+  end
+
+  protected def self.make_fall_test_aabb(
+    feet : Vec3d, entity_aabb : AABBd,
+    dx : Float64, dz : Float64, max_fall_dist : Float64, epsilon : Float64,
+  ) : AABBd
+    AABBd.new(
+      entity_aabb.min.x + epsilon + dx + feet.x,
+      feet.y - max_fall_dist - epsilon,
+      entity_aabb.min.z + epsilon + dz + feet.z,
+      entity_aabb.max.x - epsilon + dx + feet.x,
+      feet.y,
+      entity_aabb.max.z - epsilon + dz + feet.z,
+    )
   end
 
   private def sync_with_server

--- a/src/rosegold/world/player.cr
+++ b/src/rosegold/world/player.cr
@@ -28,6 +28,7 @@ class Rosegold::Player
     effects : Array(EntityEffect) = [] of EntityEffect,
     flying_speed : Float32 = 0.05_f32,
     field_of_view_modifier : Float32 = 0.1_f32
+  property fall_distance : Float64 = 0.0
   property? \
     on_ground : Bool = false,
     sneaking : Bool = false,


### PR DESCRIPTION
## Summary
- Implements Minecraft's `maybeBackOffFromEdge` algorithm in physics.cr
- When sneaking, iteratively reduces horizontal movement by 0.05 increments to prevent walking off edges with a drop >= 0.6 blocks (5/8 of a block)
- Adds `fall_distance` tracking to Player for the `above_ground?` check

## Test plan
- [x] Model spec: 5 tests covering edge walk-off, diagonal, free movement, and center movement
- [x] Integration spec: 2 tests on live server — sneak stays on block, no-sneak falls off

Fixes #19