### PR TITLE
Add persistent AdminBot for test orchestration

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         crystal_version:
-          - 1.17.0
+          - 1.19.1
           - latest
         experimental:
           - false

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.shards/
 *.dwarf
 *.env*
+.spectator-failures
 
 # binaries
 /play

--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       SPAWN_PROTECTION: 0
       SPAWN_MONSTERS: "FALSE"
       SPAWN_ANIMALS: "FALSE"
+      EXISTING_OPS_FILE: SKIP
       RCON_CMDS_STARTUP: |-
         gamerule spawn_mobs false
       # TYPE: PAPER

--- a/spec/fixtures/server/ops.json
+++ b/spec/fixtures/server/ops.json
@@ -12,8 +12,8 @@
     "bypassesPlayerLimit": false
   },
   {
-    "uuid": "810bc3ed-7c1a-3dcd-9adc-383cfd922e7f",
-    "name": "grepsedawk",
+    "uuid": "ac05f26e-c3db-3f24-898e-263087468b84",
+    "name": "rosegoldadmin",
     "level": 4,
     "bypassesPlayerLimit": false
   }

--- a/spec/integration/attack_spec.cr
+++ b/spec/integration/attack_spec.cr
@@ -6,44 +6,34 @@ end
 
 Spectator.describe "Rosegold::Bot attack" do
   after_all do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
-        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
-        bot.wait_ticks 5
-      end
-    end
+    admin.setup_arena
+    admin.wait_ticks 4
   end
 
   it "should be able to attack even if the target is moving" do
+    admin.setup_arena
+    admin.wait_ticks 19
+    admin.time_set 13000
+    admin.fill -10, -60, 8, 0, -58, 6, "obsidian"
+    admin.fill -9, -60, 7, 0, -58, 7, "air"
+    admin.wait_ticks 5
+    admin.fill -6, -60, 7, -6, -60, 7, "water"
+    admin.wait_tick
+    admin.fill -9, -59, 8, -9, -59, 8, "air"
+    admin.wait_tick
+    admin.chat "/kill @e[type=zombie]"
+    admin.wait_ticks 10
+    admin.summon "zombie", -7, -60, 7
+    admin.wait_ticks 10
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Setup (inlined from before_each to avoid extra reconnect cycle)
-        bot.chat "/kill @e[type=!minecraft:player]"
-        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
-        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
-        bot.wait_ticks 20 # Wait for entity despawn and world rebuild
-        bot.chat "/tp @p -9 -60 9"
-        bot.chat "/time set 13000"
-        bot.chat "/clear"
-        bot.wait_ticks 5
-        bot.chat "/give #{bot.username} minecraft:diamond_sword[enchantments={\"minecraft:sharpness\":5}]"
-        bot.wait_ticks 5
-        bot.chat "/effect give #{bot.username} minecraft:strength 60 2"
-        bot.wait_ticks 5
-        bot.chat "/fill -10 -60 8 0 -58 6 minecraft:obsidian"
-        bot.chat "/fill -9 -60 7 0 -58 7 minecraft:air"
-        bot.wait_ticks 5
-        bot.chat "/fill -6 -60 7 -6 -60 7 minecraft:water"
-        bot.wait_tick
-
-        bot.chat "/fill -9 -59 8 -9 -59 8 minecraft:air"
-        bot.wait_tick
-        bot.chat "/kill @e[type=zombie]"
-        bot.wait_ticks 10
-        bot.chat "/summon minecraft:zombie -7 -60 7"
-        bot.wait_ticks 20
+        admin.tp -9, -60, 9
+        admin.clear
+        admin.wait_ticks 5
+        admin.give "diamond_sword[enchantments={\"minecraft:sharpness\":5}]"
+        admin.wait_ticks 5
+        admin.effect_give "strength", 60, 2
+        admin.wait_ticks 5
 
         bot.inventory.pick! "diamond_sword"
         bot.yaw = 180
@@ -67,31 +57,27 @@ Spectator.describe "Rosegold::Bot attack" do
   end
 
   it "should not be able to attack entities through blocks" do
+    admin.setup_arena
+    admin.wait_ticks 19
+    admin.time_set 13000
+    admin.fill -10, -60, 8, 0, -58, 6, "obsidian"
+    admin.fill -9, -60, 7, 0, -58, 7, "air"
+    admin.wait_ticks 5
+    admin.fill -6, -60, 7, -6, -60, 7, "water"
+    admin.wait_tick
+    admin.chat "/kill @e[type=zombie]"
+    admin.wait_ticks 5
+    admin.summon "zombie", -7, -60, 7
+    admin.wait_ticks 5
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Setup (inlined from before_each to avoid extra reconnect cycle)
-        bot.chat "/kill @e[type=!minecraft:player]"
-        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
-        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
-        bot.wait_ticks 20 # Wait for entity despawn and world rebuild
-        bot.chat "/tp @p -9 -60 9"
-        bot.chat "/time set 13000"
-        bot.chat "/clear"
-        bot.wait_ticks 5
-        bot.chat "/give #{bot.username} minecraft:diamond_sword[enchantments={\"minecraft:sharpness\":5}]"
-        bot.wait_ticks 5
-        bot.chat "/effect give #{bot.username} minecraft:strength 60 2"
-        bot.wait_ticks 5
-        bot.chat "/fill -10 -60 8 0 -58 6 minecraft:obsidian"
-        bot.chat "/fill -9 -60 7 0 -58 7 minecraft:air"
-        bot.wait_ticks 5
-        bot.chat "/fill -6 -60 7 -6 -60 7 minecraft:water"
-        bot.wait_tick
-
-        bot.chat "/kill @e[type=zombie]"
-        bot.wait_ticks 5
-        bot.chat "/summon minecraft:zombie -7 -60 7"
-        bot.wait_ticks 5
+        admin.tp -9, -60, 9
+        admin.clear
+        admin.wait_ticks 5
+        admin.give "diamond_sword[enchantments={\"minecraft:sharpness\":5}]"
+        admin.wait_ticks 5
+        admin.effect_give "strength", 60, 2
+        admin.wait_ticks 5
         bot.inventory.pick! "diamond_sword"
 
         # Aim towards the zombie (south, towards negative Z)

--- a/spec/integration/bed_spec.cr
+++ b/spec/integration/bed_spec.cr
@@ -2,32 +2,20 @@ require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot bed interactions" do
   before_all do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-        # Clear a test area
-        bot.chat "/fill -10 -60 -10 10 -55 10 minecraft:air"
-        # Set bedrock floor
-        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
-        bot.wait_tick
-      end
-    end
+    admin.kill_entities
+    admin.fill -10, -60, -10, 10, -55, 10, "air"
+    admin.fill -10, -61, -10, 10, -61, 10, "bedrock"
+    admin.wait_tick
   end
 
   it "should be able to get in and out of bed successfully" do
+    admin.time_set "night"
+    admin.setblock 0, -60, 0, "red_bed[part=foot,facing=north]"
+    admin.setblock 0, -60, 1, "red_bed[part=head,facing=north]"
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Set time to night to allow sleeping
-        bot.chat "/time set night"
-        bot.wait_tick
-
-        # Place a bed at a specific location
-        bot.chat "/setblock 0 -60 0 minecraft:red_bed[part=foot,facing=north]"
-        bot.chat "/setblock 0 -60 1 minecraft:red_bed[part=head,facing=north]"
-        bot.wait_tick
-
-        # Teleport the bot directly to the bed position
-        bot.chat "/tp 0.5 -60 0.5"
+        admin.tp 0.5, -60, 0.5
         bot.wait_tick
 
         # Interact with the bed to get in (look down at the bed)
@@ -50,19 +38,13 @@ Spectator.describe "Rosegold::Bot bed interactions" do
   end
 
   it "should handle bed interaction during the day" do
+    admin.time_set "day"
+    admin.setblock 2, -60, 0, "blue_bed[part=foot,facing=east]"
+    admin.setblock 3, -60, 0, "blue_bed[part=head,facing=east]"
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Set time to day
-        bot.chat "/time set day"
-        bot.wait_tick
-
-        # Place a bed
-        bot.chat "/setblock 2 -60 0 minecraft:blue_bed[part=foot,facing=east]"
-        bot.chat "/setblock 3 -60 0 minecraft:blue_bed[part=head,facing=east]"
-        bot.wait_tick
-
-        # Teleport the bot to the bed
-        bot.chat "/tp 2.5 -60 0.5"
+        admin.tp 2.5, -60, 0.5
         bot.wait_tick
 
         # Try to interact with the bed during day
@@ -85,19 +67,13 @@ Spectator.describe "Rosegold::Bot bed interactions" do
   end
 
   it "should handle bed interaction at night" do
+    admin.time_set "night"
+    admin.setblock 4, -60, 0, "green_bed[part=foot,facing=west]"
+    admin.setblock 3, -60, 0, "green_bed[part=head,facing=west]"
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Set time to night to allow sleeping
-        bot.chat "/time set night"
-        bot.wait_tick
-
-        # Place a bed
-        bot.chat "/setblock 4 -60 0 minecraft:green_bed[part=foot,facing=west]"
-        bot.chat "/setblock 3 -60 0 minecraft:green_bed[part=head,facing=west]"
-        bot.wait_tick
-
-        # Teleport the bot to the bed
-        bot.chat "/tp 3.5 -60 0.5"
+        admin.tp 3.5, -60, 0.5
         bot.wait_tick
 
         # Interact with the bed at night

--- a/spec/integration/bot_event_emitter_spec.cr
+++ b/spec/integration/bot_event_emitter_spec.cr
@@ -8,7 +8,7 @@ Spectator.describe "Rosegold::Bot event emitter" do
         bot.on Rosegold::Clientbound::DisguisedChatMessage do |_|
           test = true
         end
-        bot.chat "/say Hello from bot event emitter test!"
+        admin.chat "/say Hello from bot event emitter test!"
         client.wait_for Rosegold::Clientbound::DisguisedChatMessage
         expect(test).to be true
       end
@@ -22,7 +22,7 @@ Spectator.describe "Rosegold::Bot event emitter" do
         uuid = bot.on Rosegold::Clientbound::DisguisedChatMessage do |_|
           test = true
         end
-        bot.chat "/say Hello from bot event emitter test!"
+        admin.chat "/say Hello from bot event emitter test!"
         client.wait_for Rosegold::Clientbound::DisguisedChatMessage
         expect(test).to be true
         expect(uuid).to be_a UUID
@@ -39,9 +39,9 @@ Spectator.describe "Rosegold::Bot event emitter" do
           bot.once Rosegold::Clientbound::DisguisedChatMessage do |_event|
             test += 1
           end
-          bot.chat "/say First message"
+          admin.chat "/say First message"
           client.wait_for Rosegold::Clientbound::DisguisedChatMessage
-          bot.chat "/say Second message"
+          admin.chat "/say Second message"
           client.wait_for Rosegold::Clientbound::DisguisedChatMessage
           expect(test).to eq 1
         end
@@ -59,7 +59,7 @@ Spectator.describe "Rosegold::Bot event emitter" do
           end
 
           expect(ran_event).to be nil
-          bot.chat "/say Hello from wait_for test!"
+          admin.chat "/say Hello from wait_for test!"
           ticks = 0
           until ran_event || ticks > 100
             bot.wait_tick
@@ -80,8 +80,7 @@ Spectator.describe "Rosegold::Bot event emitter" do
             end
 
             expect(ran_event).to be nil
-            bot.chat "/say Hello from timeout test!"
-            # until ran event or 5 seconds
+            admin.chat "/say Hello from timeout test!"
             ticks = 0
             until ran_event || ticks > 100
               bot.wait_tick
@@ -102,7 +101,7 @@ Spectator.describe "Rosegold::Bot event emitter" do
 
             expect(ran_event).to be nil
             bot.wait_tick # enough to go beyond the 1 nanosecond timeout
-            bot.chat "/say This should timeout!"
+            admin.chat "/say This should timeout!"
             bot.wait_tick
             expect(ran_event).to be nil
           end

--- a/spec/integration/button_spec.cr
+++ b/spec/integration/button_spec.cr
@@ -2,21 +2,17 @@ require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot button interactions" do
   before_all do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 0 -60 0"
-      end
-    end
+    admin.tp 0, -60, 0
   end
   it "should be able to push a stone button on the ground" do
+    admin.fill 5, -61, 5, 7, -59, 5, "air"
+    admin.wait_ticks 5
+    admin.setblock 5, -61, 5, "stone_button[face=floor]"
+    admin.wait_ticks 5
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 5.5 -60 5.5"
-        bot.wait_ticks 5
-        bot.chat "/fill 5 -61 5 7 -59 5 minecraft:air"
-        bot.wait_ticks 5
-        bot.chat "/setblock 5 -61 5 minecraft:stone_button[face=floor]"
-        bot.wait_ticks 20
+        admin.tp 5.5, -60, 5.5
+        bot.wait_ticks 15
 
         bot.pitch = 90
         bot.wait_ticks 15
@@ -46,23 +42,19 @@ Spectator.describe "Rosegold::Bot button interactions" do
         post_name = Rosegold::MCData.default.block_state_names[post_button_state.as(UInt16)]
         expect(post_name).to contain("powered=false")
 
-        bot.chat "/fill 5 -61 5 7 -59 5 minecraft:air"
+        admin.fill 5, -61, 5, 7, -59, 5, "air"
         bot.wait_tick
       end
     end
   end
 
   it "should be able to push a stone button on the wall" do
+    admin.setblock 3, -60, 3, "stone"
+    admin.setblock 4, -60, 3, "stone_button[face=wall,facing=east]"
+    admin.wait_ticks 5
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Use z=3 to avoid any interference from other tests
-        # Place stone wall and button (facing east = button on west face of block, protruding east)
-        bot.chat "/setblock 3 -60 3 minecraft:stone"
-        bot.chat "/setblock 4 -60 3 minecraft:stone_button[face=wall,facing=east]"
-        bot.wait_ticks 20
-
-        # Bot stands on untouched grass at (5,-60,3.5), feet at -59, eyes at -57.38
-        bot.chat "/tp 5 -60 3.5"
+        admin.tp 5, -60, 3.5
         bot.wait_ticks 15
 
         initial_button_state = client.dimension.block_state(4, -60, 3)
@@ -87,8 +79,8 @@ Spectator.describe "Rosegold::Bot button interactions" do
         post_name = Rosegold::MCData.default.block_state_names[post_button_state.as(UInt16)]
         expect(post_name).to contain("powered=false")
 
-        bot.chat "/setblock 3 -60 3 minecraft:air"
-        bot.chat "/setblock 4 -60 3 minecraft:air"
+        admin.setblock 3, -60, 3, "air"
+        admin.setblock 4, -60, 3, "air"
         bot.wait_tick
       end
     end

--- a/spec/integration/chunk_batch_spec.cr
+++ b/spec/integration/chunk_batch_spec.cr
@@ -4,8 +4,7 @@ Spectator.describe "Chunk Batch Timing Integration" do
   it "should handle chunk batch timing correctly" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Move to a new area to trigger chunk loading
-        bot.chat "/tp 100 -60 100"
+        admin.tp 100, -60, 100
         bot.wait_tick
 
         # Wait a bit for chunk batches to be processed

--- a/spec/integration/crafting_spec.cr
+++ b/spec/integration/crafting_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 private def wait_for_recipes(bot, min_count = 100, timeout_ticks = 60)
-  bot.chat "/recipe give @s *"
+  admin.chat "/recipe give #{AdminBot::TEST_PLAYER} *"
   timeout_ticks.times do
     break if bot.recipe_registry.size >= min_count
     bot.wait_ticks 1
@@ -77,9 +77,9 @@ Spectator.describe "Rosegold::Bot crafting" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
-          bot.chat "/clear"
-          bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:oak_log 1"
+          admin.clear
+          admin.wait_ticks 5
+          admin.give "oak_log", 1
           bot.wait_ticks 10
 
           recipes = bot.recipes_for("oak_planks")
@@ -93,7 +93,7 @@ Spectator.describe "Rosegold::Bot crafting" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
-          bot.chat "/clear"
+          admin.clear
           bot.wait_ticks 10
 
           recipes = bot.recipes_for("oak_planks")
@@ -109,9 +109,9 @@ Spectator.describe "Rosegold::Bot crafting" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
-          bot.chat "/clear"
-          bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:oak_log 4"
+          admin.clear
+          admin.wait_ticks 5
+          admin.give "oak_log", 4
           bot.wait_ticks 10
 
           bot.craft("oak_planks", 4)
@@ -126,9 +126,9 @@ Spectator.describe "Rosegold::Bot crafting" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
-          bot.chat "/clear"
-          bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:oak_planks 2"
+          admin.clear
+          admin.wait_ticks 5
+          admin.give "oak_planks", 2
           bot.wait_ticks 10
 
           bot.craft("stick")
@@ -143,9 +143,9 @@ Spectator.describe "Rosegold::Bot crafting" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
-          bot.chat "/clear"
-          bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:oak_log 8"
+          admin.clear
+          admin.wait_ticks 5
+          admin.give "oak_log", 8
           bot.wait_ticks 10
 
           bot.craft("oak_planks", 8)
@@ -157,16 +157,16 @@ Spectator.describe "Rosegold::Bot crafting" do
     end
 
     it "crafts with a crafting table for 3x3 recipes" do
+      admin.setblock 2, -59, 0, "crafting_table"
+      admin.wait_ticks 5
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
-          bot.chat "/clear"
-          bot.wait_ticks 5
-          bot.chat "/tp #{bot.username} 0 -59 0"
+          admin.clear
+          admin.wait_ticks 5
+          admin.tp 0, -59, 0
           bot.wait_ticks 10
-          bot.chat "/setblock 2 -59 0 minecraft:crafting_table"
-          bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:cobblestone 8"
+          admin.give "cobblestone", 8
           bot.wait_ticks 10
 
           bot.craft("furnace", table: Rosegold::Vec3i.new(2, -59, 0))
@@ -183,9 +183,9 @@ Spectator.describe "Rosegold::Bot crafting" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
-          bot.chat "/clear"
-          bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:oak_log 4"
+          admin.clear
+          admin.wait_ticks 5
+          admin.give "oak_log", 4
           bot.wait_ticks 10
 
           bot.craft_all("oak_planks")
@@ -202,7 +202,7 @@ Spectator.describe "Rosegold::Bot crafting" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
-          bot.chat "/clear"
+          admin.clear
           bot.wait_ticks 10
 
           expect { bot.craft("diamond_sword") }.to raise_error(Rosegold::Bot::CraftingError)
@@ -225,9 +225,9 @@ Spectator.describe "Rosegold::Bot crafting" do
     it "crafts planks from a log using manual grid placement" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
-          bot.chat "/clear"
-          bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:oak_log 1"
+          admin.clear
+          admin.wait_ticks 5
+          admin.give "oak_log", 1
           bot.wait_ticks 10
 
           bot.craft_pattern([["oak_log"]])
@@ -241,9 +241,9 @@ Spectator.describe "Rosegold::Bot crafting" do
     it "crafts a crafting table using manual 2x2 pattern" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
-          bot.chat "/clear"
-          bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:oak_planks 4"
+          admin.clear
+          admin.wait_ticks 5
+          admin.give "oak_planks", 4
           bot.wait_ticks 10
 
           bot.craft_pattern([
@@ -260,7 +260,7 @@ Spectator.describe "Rosegold::Bot crafting" do
     it "raises CraftingError when item not in inventory" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
-          bot.chat "/clear"
+          admin.clear
           bot.wait_ticks 10
 
           expect { bot.craft_pattern([["diamond", "diamond", "diamond"]]) }.to raise_error(Rosegold::Bot::CraftingError)

--- a/spec/integration/disconnection_spec.cr
+++ b/spec/integration/disconnection_spec.cr
@@ -13,8 +13,8 @@ Spectator.describe "Rosegold::Client disconnection" do
       end
 
       Rosegold::Bot.new(client).try do |bot|
-        username = client.player.username
-        bot.chat "/kick #{username}"
+        bot.wait_ticks 5
+        admin.chat "/kick #{AdminBot::TEST_PLAYER}"
         bot.wait_ticks 10
 
         expect(disconnected).to be_true
@@ -28,8 +28,8 @@ Spectator.describe "Rosegold::Client disconnection" do
       begin
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            username = client.player.username
-            bot.chat "/kick #{username}"
+            bot.wait_ticks 5
+            admin.chat "/kick #{AdminBot::TEST_PLAYER}"
             bot.wait_ticks 10
           end
         end

--- a/spec/integration/effects_spec.cr
+++ b/spec/integration/effects_spec.cr
@@ -4,26 +4,21 @@ Spectator.describe "Rosegold::Bot effects" do
   it "should add and remove effects properly" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/effect clear #{bot.username}"
+        admin.effect_clear
         bot.wait_ticks 2
 
-        # Verify no haste effect initially
         expect(client.player.effect_by_name("haste")).to be_nil
 
-        # Apply haste effect for longer duration (60 seconds)
-        bot.chat "/effect give #{bot.username} minecraft:haste 60 2"
+        admin.effect_give "haste", 60, 2
         client.wait_for Rosegold::Clientbound::EntityEffect
 
-        # Verify haste was added to the player
         haste_effect = client.player.effect_by_name("haste")
         expect(haste_effect).to_not be_nil
         expect(haste_effect.try &.amplifier).to eq(2)
 
-        # Manually clear effects to test removal
-        bot.chat "/effect clear #{bot.username}"
+        admin.effect_clear
         client.wait_for Rosegold::Clientbound::RemoveEntityEffect
 
-        # Verify haste effect was removed
         expect(client.player.effect_by_name("haste")).to be_nil
       end
     end

--- a/spec/integration/iceroad_spec.cr
+++ b/spec/integration/iceroad_spec.cr
@@ -2,22 +2,22 @@ require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot ice road physics" do
   it "should achieve high speed ice road movement" do
+    admin.kill_entities
+
+    base_y = -61
+    start_pos = Rosegold::Vec3d.new(20.5, base_y + 1.0, 0.5)
+    test_distance = 30.0
+    end_pos = Rosegold::Vec3d.new(20.5, base_y + 1.0, test_distance)
+
+    admin.fill 20, base_y, 0, 20, base_y, 40, "ice"
+    admin.fill 20, base_y + 1, 0, 20, base_y + 1, 40, "stone_button[face=floor]"
+    admin.fill 20, base_y + 2, 0, 20, base_y + 2, 40, "oak_trapdoor[half=top]"
+    admin.fill 20, base_y + 3, 0, 20, base_y + 3, 40, "obsidian"
+    admin.wait_ticks 5
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-
-        base_y = -61
-        start_pos = Rosegold::Vec3d.new(20.5, base_y + 1.0, 0.5)
-        test_distance = 30.0
-        end_pos = Rosegold::Vec3d.new(20.5, base_y + 1.0, test_distance)
-
-        bot.chat "/fill 20 #{base_y} 0 20 #{base_y} 40 minecraft:ice"
-        bot.chat "/fill 20 #{base_y + 1} 0 20 #{base_y + 1} 40 minecraft:stone_button[face=floor]"
-        bot.chat "/fill 20 #{base_y + 2} 0 20 #{base_y + 2} 40 minecraft:oak_trapdoor[half=top]"
-        bot.chat "/fill 20 #{base_y + 3} 0 20 #{base_y + 3} 40 minecraft:obsidian"
-
-        bot.chat "/tp #{start_pos.x} #{start_pos.y} #{start_pos.z}"
-        bot.chat "/give @s minecraft:baked_potato 64"
+        admin.tp start_pos.x, start_pos.y, start_pos.z
+        admin.give "baked_potato", 64
         bot.wait_ticks 15
 
         bot.eat!

--- a/spec/integration/interactions_spec.cr
+++ b/spec/integration/interactions_spec.cr
@@ -2,13 +2,9 @@ require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot interactions" do
   before_all do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
-        bot.wait_ticks 20
-      end
-    end
+    admin.kill_entities
+    admin.fill -10, -60, -10, 10, 0, 10, "air"
+    admin.wait_ticks 20
   end
 
   it "should be able to chat" do
@@ -22,15 +18,13 @@ Spectator.describe "Rosegold::Bot interactions" do
   end
 
   it "should be able to dig continuously through 3 blocks" do
+    admin.fill 9, -60, 10, 9, -58, 10, "dirt"
+    admin.wait_ticks 5
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.wait_ticks 5
-        bot.chat "/clear"
-        bot.wait_ticks 5
-        # Set up a column of 3 dirt blocks below the bot
-        bot.chat "/fill 9 -60 10 9 -58 10 minecraft:dirt"
-        bot.wait_ticks 10
-        bot.chat "/tp 9 -57 10"
+        admin.clear
+        admin.wait_ticks 5
+        admin.tp 9, -57, 10
         bot.wait_ticks 10
 
         bot.look &.down
@@ -78,12 +72,11 @@ Spectator.describe "Rosegold::Bot interactions" do
   end
 
   it "should stop digging when bot.stop_digging is called" do
+    admin.fill 10, -60, 9, 10, -57, 9, "dirt"
+    admin.wait_ticks 5
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.wait_ticks 5
-        bot.chat "/fill 10 -60 9 10 -57 9 minecraft:dirt"
-        bot.wait_ticks 10
-        bot.chat "/tp 10 -56 9"
+        admin.tp 10, -56, 9
         bot.wait_ticks 15
 
         bot.look &.down
@@ -99,16 +92,15 @@ Spectator.describe "Rosegold::Bot interactions" do
   end
 
   it "should be able to dig stone with diamond pickaxe (in a reasonable amount of time)" do
+    admin.fill 8, -60, 8, 8, -60, 8, "stone"
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Set up stone block and give diamond pickaxe
-        bot.chat "/fill 8 -60 8 8 -60 8 minecraft:stone"
-        bot.chat "/clear"
-        bot.wait_ticks 5
-        bot.chat "/give @p minecraft:diamond_pickaxe 1"
-        bot.wait_ticks 10 # Wait for /fill, /clear, and /give to all complete
-        bot.chat "/tp 8 -59 8"
-        bot.wait_ticks 10 # Wait for teleport and chunk updates
+        admin.clear
+        admin.wait_ticks 5
+        admin.give "diamond_pickaxe"
+        admin.wait_ticks 10
+        admin.tp 8, -59, 8
+        bot.wait_ticks 10
 
         # Equip the diamond pickaxe
         bot.inventory.pick! "diamond_pickaxe"
@@ -150,16 +142,15 @@ Spectator.describe "Rosegold::Bot interactions" do
   end
 
   it "should be able to dig obsidian with diamond pickaxe and efficiency" do
+    admin.fill 9, -60, 9, 9, -60, 9, "obsidian"
+    admin.wait_ticks 5
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Set up obsidian block and give diamond pickaxe with efficiency
-        bot.chat "/fill 9 -60 9 9 -60 9 minecraft:obsidian"
-        bot.wait_ticks 5
-        bot.chat "/clear"
-        bot.wait_ticks 5
-        bot.chat "/give @p minecraft:diamond_pickaxe[enchantments={\"minecraft:efficiency\":5}] 1"
-        bot.wait_ticks 5
-        bot.chat "/tp 9 -59 9"
+        admin.clear
+        admin.wait_ticks 5
+        admin.give "diamond_pickaxe[enchantments={\"minecraft:efficiency\":5}]"
+        admin.wait_ticks 5
+        admin.tp 9, -59, 9
         bot.wait_ticks 10
 
         # Equip the efficiency 5 diamond pickaxe
@@ -204,15 +195,15 @@ Spectator.describe "Rosegold::Bot interactions" do
   end
 
   it "should be able to place blocks" do
+    admin.kill_entities
+    admin.wait_ticks 5
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-        bot.wait_ticks 5
-        bot.chat "/tp 10 -60 10"
+        admin.tp 10, -60, 10
         bot.wait_ticks 10
-        bot.chat "/clear"
-        bot.wait_ticks 10
-        bot.chat "/give @p minecraft:obsidian 64"
+        admin.clear
+        admin.wait_ticks 10
+        admin.give "obsidian", 64
         bot.wait_ticks 10
 
         bot.inventory.pick! "obsidian"
@@ -238,9 +229,9 @@ Spectator.describe "Rosegold::Bot interactions" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         # Mimic vine farm: stone above, vine hangs below with inherited face
-        bot.chat "/setblock 5 -59 6 minecraft:stone"
-        bot.chat "/setblock 5 -60 6 minecraft:vine[west=true]"
-        bot.wait_ticks 10
+        admin.setblock 5, -59, 6, "stone"
+        admin.setblock 5, -60, 6, "vine[west=true]"
+        admin.wait_ticks 10
 
         vine_state = client.dimension.block_state(5, -60, 6)
         vine_name = Rosegold::MCData.default.block_state_names[vine_state.as(UInt16)]
@@ -250,10 +241,10 @@ Spectator.describe "Rosegold::Bot interactions" do
         # Bot at same Y as vine, ~1.5 blocks west
         # Eyes at y=-58.38, vine hitbox y=-60 to y=-59
         # At x-distance 1.5, ray y = -58.38 - 1.258 = -59.64 → inside vine range
-        bot.chat "/tp 3.5 -60 6.5"
-        bot.chat "/clear"
-        bot.chat "/give @p minecraft:shears 1"
-        bot.wait_ticks 10
+        admin.tp 3.5, -60, 6.5
+        admin.clear
+        admin.give "shears"
+        admin.wait_ticks 10
 
         bot.inventory.pick! "shears"
         bot.wait_ticks 5
@@ -283,14 +274,13 @@ Spectator.describe "Rosegold::Bot interactions" do
   end
 
   it "should raytrace wheat crops with age-dependent hitboxes" do
+    admin.setblock 6, -60, 6, "farmland"
+    admin.setblock 6, -59, 6, "wheat[age=0]"
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Setup: place wheat at age 0 (tiny, 2 pixels tall) and give bonemeal
-        bot.chat "/setblock 6 -60 6 minecraft:farmland"
-        bot.chat "/setblock 6 -59 6 minecraft:wheat[age=0]"
-        bot.chat "/tp 6.5 -60 7.5"
-        bot.chat "/clear"
-        bot.chat "/give @p minecraft:bone_meal 10"
+        admin.tp 6.5, -60, 7.5
+        admin.clear
+        admin.give "bone_meal", 10
         bot.wait_ticks 5
 
         # Verify wheat was created at age 0

--- a/spec/integration/inventory_spec.cr
+++ b/spec/integration/inventory_spec.cr
@@ -6,7 +6,7 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "returns 0" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             expect(bot.inventory.count("bucket")).to eq 0
@@ -19,12 +19,12 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "returns the sum of their counts" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
-            bot.chat "/give #{bot.username} minecraft:bucket 16"
-            bot.chat "/give #{bot.username} minecraft:bucket 1"
-            bot.chat "/give #{bot.username} minecraft:bucket 5"
+            admin.give "bucket", 16
+            admin.give "bucket", 1
+            admin.give "bucket", 5
             bot.wait_ticks 5
 
             expect(bot.inventory.count("bucket")).to eq 16 + 1 + 5
@@ -37,10 +37,10 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "doesn't overflow" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
-            bot.chat "/give #{bot.username} minecraft:bucket 513"
+            admin.give "bucket", 513
             bot.wait_ticks 5
 
             expect(bot.inventory.count("bucket")).to eq 513
@@ -55,7 +55,7 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "returns false" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             expect(bot.inventory.pick("diamond_pickaxe")).to eq false
@@ -70,11 +70,11 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "returns true" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
-            bot.chat "/give #{bot.username} minecraft:stone 42"
+            admin.give "stone", 42
             bot.wait_ticks 5
-            bot.chat "/give #{bot.username} minecraft:grass_block 43"
+            admin.give "grass_block", 43
             bot.wait_ticks 5
 
             expect(bot.inventory.pick("stone")).to eq true
@@ -90,11 +90,11 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "returns true" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
-            bot.chat "/give #{bot.username} minecraft:stone #{64*9}"
+            admin.give "stone", 64*9
             bot.wait_ticks 10
-            bot.chat "/give #{bot.username} minecraft:grass_block 1"
+            admin.give "grass_block"
             bot.wait_ticks 5
 
             expect(bot.inventory.pick("grass_block")).to eq true
@@ -108,13 +108,13 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "picks items with lower durability first" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
             # Give undamaged diamond pickaxe first (will go to hotbar slot 0)
-            bot.chat "/give #{bot.username} minecraft:diamond_pickaxe"
+            admin.give "diamond_pickaxe"
             bot.wait_ticks 5
             # Give damaged diamond pickaxe (will go to hotbar slot 1)
-            bot.chat "/give #{bot.username} minecraft:diamond_pickaxe[damage=1400]"
+            admin.give "diamond_pickaxe[damage=1400]"
             bot.wait_ticks 5
 
             # Switch away from the pickaxes first
@@ -139,7 +139,7 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "raises exception" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
             expect { bot.inventory.pick!("diamond_pickaxe") }.to raise_error(Rosegold::Inventory::ItemNotFoundError)
           end
@@ -151,9 +151,9 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "raises exception" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
-            bot.chat "/give #{bot.username} minecraft:diamond_pickaxe[damage=1550,enchantments={\"minecraft:efficiency\":1}] 1"
+            admin.give "diamond_pickaxe[damage=1550,enchantments={\"minecraft:efficiency\":1}]"
             bot.wait_ticks 5
             expect { bot.inventory.pick!("diamond_pickaxe") }.to raise_error(Rosegold::Inventory::ItemNotFoundError)
           end
@@ -166,11 +166,11 @@ Spectator.describe "Rosegold::Bot inventory" do
     it "updates the inventory locally to be the same as externally" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
-          bot.chat "/tp #{bot.username} 30 -60 30"
-          bot.chat "/setblock 21 -60 21 minecraft:air"
+          admin.tp 30, -60, 30
+          admin.setblock 21, -60, 21, "air"
           bot.wait_tick
-          bot.chat "/setblock 30 -61 30 minecraft:chest{Items:[{Slot:7b, id: \"minecraft:diamond_sword\",count:1b},{Slot:6b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":100}}]}"
-          bot.chat "/clear"
+          admin.setblock 30, -61, 30, "chest{Items:[{Slot:7b, id: \"minecraft:diamond_sword\",count:1b},{Slot:6b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":100}}]}"
+          admin.clear
           bot.wait_ticks 5
           bot.pitch = 90
           bot.wait_ticks 20
@@ -209,13 +209,13 @@ Spectator.describe "Rosegold::Bot inventory" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           # Teleport to known location and clear area
-          bot.chat "/tp 30 -60 30"
+          admin.tp 30, -60, 30
           bot.wait_tick
-          bot.chat "/fill 29 -62 29 31 -58 31 minecraft:air"
+          admin.fill 29, -62, 29, 31, -58, 31, "air"
           bot.wait_tick
           # Create chest with two diamond pickaxes: one undamaged, one heavily damaged
-          bot.chat "/setblock 30 -61 30 minecraft:chest{Items:[{Slot:0b, id: \"minecraft:diamond_pickaxe\",count:1b},{Slot:1b, id: \"minecraft:diamond_pickaxe\",count:1b,components:{\"minecraft:damage\":1400}}]}"
-          bot.chat "/clear"
+          admin.setblock 30, -61, 30, "chest{Items:[{Slot:0b, id: \"minecraft:diamond_pickaxe\",count:1b},{Slot:1b, id: \"minecraft:diamond_pickaxe\",count:1b,components:{\"minecraft:damage\":1400}}]}"
+          admin.clear
           bot.wait_ticks 5
           bot.wait_tick
 
@@ -248,13 +248,13 @@ Spectator.describe "Rosegold::Bot inventory" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           # Teleport to known location and clear area
-          bot.chat "/tp 30 -60 30"
+          admin.tp 30, -60, 30
           bot.wait_tick
-          bot.chat "/fill 29 -62 29 31 -58 31 minecraft:air"
+          admin.fill 29, -62, 29, 31, -58, 31, "air"
           bot.wait_tick
           # Create chest with multiple diamond swords of varying durability
-          bot.chat "/setblock 30 -61 30 minecraft:chest{Items:[{Slot:0b, id: \"minecraft:diamond_sword\",count:1b},{Slot:1b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":800}},{Slot:2b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":1200}},{Slot:3b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":400}}]}"
-          bot.chat "/clear"
+          admin.setblock 30, -61, 30, "chest{Items:[{Slot:0b, id: \"minecraft:diamond_sword\",count:1b},{Slot:1b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":800}},{Slot:2b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":1200}},{Slot:3b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":400}}]}"
+          admin.clear
           bot.wait_ticks 5
           bot.wait_tick
 
@@ -287,16 +287,16 @@ Spectator.describe "Rosegold::Bot inventory" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           # Teleport to known location and clear area
-          bot.chat "/tp 30 -60 30"
+          admin.tp 30, -60, 30
           bot.wait_tick
-          bot.chat "/fill 29 -62 29 31 -58 31 minecraft:air"
+          admin.fill 29, -62, 29, 31, -58, 31, "air"
           bot.wait_tick
 
           # Create chest with exactly 20 stacks of cobblestone (20 * 64 = 1280 items)
           items_array = (0..19).map { |i| "{Slot:#{i}b,id:\"minecraft:cobblestone\",count:64b}" }
-          bot.chat "/setblock 30 -61 30 minecraft:chest{Items:[#{items_array.join(",")}]} replace"
+          admin.setblock 30, -61, 30, "chest{Items:[#{items_array.join(",")}]}", "replace"
           bot.wait_tick
-          bot.chat "/clear"
+          admin.clear
           bot.wait_ticks 5
 
           # Open the chest
@@ -330,19 +330,19 @@ Spectator.describe "Rosegold::Bot inventory" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           # Teleport to known location and clear area
-          bot.chat "/tp 30 -60 30"
+          admin.tp 30, -60, 30
           bot.wait_tick
-          bot.chat "/fill 29 -62 29 31 -58 31 minecraft:air"
+          admin.fill 29, -62, 29, 31, -58, 31, "air"
           bot.wait_tick
 
           # Create empty chest
-          bot.chat "/setblock 30 -61 30 minecraft:chest{Items:[]} replace"
+          admin.setblock 30, -61, 30, "chest{Items:[]}", "replace"
           bot.wait_tick
-          bot.chat "/clear"
+          admin.clear
           bot.wait_ticks 5
 
           # Give player exactly 20 stacks of cobblestone (1280 items)
-          bot.chat "/give #{bot.username} minecraft:cobblestone 1280"
+          admin.give "cobblestone", 1280
           bot.wait_ticks 5
 
           # Open the chest
@@ -383,7 +383,7 @@ Spectator.describe "Rosegold::Bot inventory" do
           expect(player_count_after_relog).to eq 0
 
           # Reopen the chest and verify it still has 1280 cobblestone
-          bot.chat "/tp 30 -60 30"
+          admin.tp 30, -60, 30
           bot.wait_tick
           bot.pitch = 90
           bot.use_hand
@@ -402,14 +402,14 @@ Spectator.describe "Rosegold::Bot inventory" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           # Teleport to known location and clear area
-          bot.chat "/tp 30 -60 30"
+          admin.tp 30, -60, 30
           bot.wait_tick
-          bot.chat "/fill 29 -62 29 31 -58 31 minecraft:air"
+          admin.fill 29, -62, 29, 31, -58, 31, "air"
           bot.wait_tick
-          bot.chat "/setblock 30 -61 30 minecraft:chest{Items:[]}"
-          bot.chat "/clear"
+          admin.setblock 30, -61, 30, "chest{Items:[]}"
+          admin.clear
           bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:diamond_sword 1"
+          admin.give "diamond_sword"
           bot.wait_ticks 5
 
           bot.pitch = 90
@@ -444,11 +444,11 @@ Spectator.describe "Rosegold::Bot inventory" do
     slots_before_reload = nil
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 30 -60 30"
+        admin.tp 30, -60, 30
         bot.wait_tick
         bot.wait_tick
-        bot.chat "/setblock 30 -61 30 minecraft:chest{Items:[{Slot:7b, id: \"minecraft:diamond_sword\",count:1b}]}"
-        bot.chat "/clear"
+        admin.setblock 30, -61, 30, "chest{Items:[{Slot:7b, id: \"minecraft:diamond_sword\",count:1b}]}"
+        admin.clear
 
         bot.pitch = 90
         bot.use_hand
@@ -480,11 +480,11 @@ Spectator.describe "Rosegold::Bot inventory" do
     it "throws all of the specified item" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
-          bot.chat "/clear"
+          admin.clear
           bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:diamond_sword 4"
+          admin.give "diamond_sword", 4
           bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:stone 200"
+          admin.give "stone", 200
           bot.wait_ticks 10
 
           bot.look = Rosegold::Look.new 0, 0
@@ -505,9 +505,9 @@ Spectator.describe "Rosegold::Bot inventory" do
     it "throws all lava buckets (single-stack items)" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
-          bot.chat "/clear"
+          admin.clear
           bot.wait_ticks 5
-          bot.chat "/give #{bot.username} minecraft:lava_bucket 33"
+          admin.give "lava_bucket", 33
           bot.wait_ticks 10
 
           bot.look = Rosegold::Look.new 0, 0
@@ -532,16 +532,16 @@ Spectator.describe "Rosegold::Bot inventory" do
     it "throws all items from an open container" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
-          bot.chat "throws all items from an open container"
+          bot.chat "throws all items from an open container" # debug message
           # Teleport to known location and clear area
-          bot.chat "/tp 30 -60 30"
+          admin.tp 30, -60, 30
           bot.wait_tick
 
           # Create chest with cobblestone inside (setblock replaces existing blocks)
-          bot.chat "/setblock 30 -61 30 minecraft:chest{Items:[{Slot:0b, id: \"minecraft:cobblestone\",count:1b},{Slot:1b, id: \"minecraft:cobblestone\",count:1b}]}"
+          admin.setblock 30, -61, 30, "chest{Items:[{Slot:0b, id: \"minecraft:cobblestone\",count:1b},{Slot:1b, id: \"minecraft:cobblestone\",count:1b}]}"
           bot.wait_tick
 
-          bot.chat "/clear"
+          admin.clear
           bot.wait_ticks 5
 
           # Open the chest
@@ -576,20 +576,20 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             # Teleport to known location and clear area
-            bot.chat "/tp 30 -60 30"
+            admin.tp 30, -60, 30
             bot.wait_tick
-            bot.chat "/fill 29 -62 29 31 -58 31 minecraft:air"
+            admin.fill 29, -62, 29, 31, -58, 31, "air"
             bot.wait_tick
 
             # Create a completely full chest using the correct NBT format
             items_array = (0..26).map { |i| "{Slot:#{i}b,id:\"minecraft:cobblestone\",count:64b}" }.join(",")
-            bot.chat "/setblock 30 -61 30 minecraft:chest{Items:[#{items_array}]} replace"
+            admin.setblock 30, -61, 30, "chest{Items:[#{items_array}]}", "replace"
             bot.wait_tick
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             # Give player diamond swords to try to deposit into the full chest
-            bot.chat "/give #{bot.username} minecraft:diamond_sword 3"
+            admin.give "diamond_sword", 3
             bot.wait_ticks 5
 
             # Open the chest
@@ -630,24 +630,24 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             # Teleport to known location and clear area
-            bot.chat "/tp 30 -60 30"
+            admin.tp 30, -60, 30
             bot.wait_tick
-            bot.chat "/fill 29 -62 29 31 -58 31 minecraft:air"
+            admin.fill 29, -62, 29, 31, -58, 31, "air"
             bot.wait_tick
 
             # Create a chest with one slot partially filled (50/64 cobblestone)
             # and give the rest of the chest filled with other items
             items_array = ["{Slot:0b,id:\"minecraft:cobblestone\",count:50b}"] +
                           (1..26).map { |i| "{Slot:#{i}b,id:\"minecraft:diamond_sword\",count:1b}" }
-            bot.chat "/setblock 30 -61 30 minecraft:chest{Items:[#{items_array.join(",")}]} replace"
+            admin.setblock 30, -61, 30, "chest{Items:[#{items_array.join(",")}]}", "replace"
             bot.wait_tick
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             # Give player diamond swords and cobblestone to deposit
-            bot.chat "/give #{bot.username} minecraft:diamond_sword 10"
+            admin.give "diamond_sword", 10
             bot.wait_ticks 5
-            bot.chat "/give #{bot.username} minecraft:cobblestone 64"
+            admin.give "cobblestone", 64
             bot.wait_ticks 5
 
             # Open the chest
@@ -709,9 +709,9 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "returns current count without withdrawing" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
-            bot.chat "/give #{bot.username} minecraft:stone 15"
+            admin.give "stone", 15
             bot.wait_ticks 5
 
             result = bot.inventory.replenish 10, "stone"
@@ -726,14 +726,14 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "withdraws additional items from container" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/fill ~ ~ ~ ~ ~ ~ minecraft:air"
-            bot.wait_tick
-            bot.chat "/setblock ~ ~ ~ air"
-            bot.chat "/setblock ~ ~-1 ~ minecraft:chest{Items:[{Slot:0b, id: \"minecraft:stone\",count:10b}]}"
-            bot.chat "/clear"
-            bot.wait_tick
-            bot.chat "/give #{bot.username} minecraft:stone 2"
-            bot.wait_ticks 5
+            admin.chat "/execute at #{AdminBot::TEST_PLAYER} run fill ~ ~ ~ ~ ~ ~ minecraft:air"
+            admin.wait_tick
+            admin.chat "/execute at #{AdminBot::TEST_PLAYER} run setblock ~ ~ ~ air"
+            admin.chat "/execute at #{AdminBot::TEST_PLAYER} run setblock ~ ~-1 ~ minecraft:chest{Items:[{Slot:0b, id: \"minecraft:stone\",count:10b}]}"
+            admin.clear
+            admin.wait_tick
+            admin.give "stone", 2
+            admin.wait_ticks 5
             bot.pitch = 90
             bot.wait_ticks 5
             bot.use_hand
@@ -752,11 +752,11 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "withdraws items from container" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/fill ~ ~ ~ ~ ~ ~ minecraft:air"
-            bot.wait_tick
-            bot.chat "/setblock ~ ~ ~ minecraft:chest{Items:[{Slot:0b, id: \"minecraft:diamond\",count:5b}]}"
-            bot.chat "/clear"
-            bot.wait_ticks 5
+            admin.chat "/execute at #{AdminBot::TEST_PLAYER} run fill ~ ~ ~ ~ ~ ~ minecraft:air"
+            admin.wait_tick
+            admin.chat "/execute at #{AdminBot::TEST_PLAYER} run setblock ~ ~ ~ minecraft:chest{Items:[{Slot:0b, id: \"minecraft:diamond\",count:5b}]}"
+            admin.clear
+            admin.wait_ticks 5
 
             bot.pitch = 90
             bot.use_hand
@@ -774,13 +774,13 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "withdraws as many as available" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/fill ~ ~ ~ ~ ~ ~ minecraft:air"
-            bot.wait_tick
-            bot.chat "/setblock ~ ~ ~ minecraft:chest{Items:[{Slot:0b, id: \"minecraft:gold_ingot\",count:2b}]}"
-            bot.chat "/clear"
-            bot.wait_ticks 5
-            bot.chat "/give #{bot.username} minecraft:gold_ingot 1"
-            bot.wait_ticks 5
+            admin.chat "/execute at #{AdminBot::TEST_PLAYER} run fill ~ ~ ~ ~ ~ ~ minecraft:air"
+            admin.wait_tick
+            admin.chat "/execute at #{AdminBot::TEST_PLAYER} run setblock ~ ~ ~ minecraft:chest{Items:[{Slot:0b, id: \"minecraft:gold_ingot\",count:2b}]}"
+            admin.clear
+            admin.wait_ticks 5
+            admin.give "gold_ingot"
+            admin.wait_ticks 5
 
             bot.pitch = 90
             bot.use_hand
@@ -802,15 +802,15 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "shift-click equipment functionality" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             # Give one full set of diamond armor and shield
-            bot.chat "/give #{bot.username} minecraft:diamond_helmet 1"
-            bot.chat "/give #{bot.username} minecraft:diamond_chestplate 1"
-            bot.chat "/give #{bot.username} minecraft:diamond_leggings 1"
-            bot.chat "/give #{bot.username} minecraft:diamond_boots 1"
-            bot.chat "/give #{bot.username} minecraft:shield 1"
+            admin.give "diamond_helmet"
+            admin.give "diamond_chestplate"
+            admin.give "diamond_leggings"
+            admin.give "diamond_boots"
+            admin.give "shield"
             bot.wait_ticks 5
 
             # Find equipment items in inventory
@@ -860,7 +860,7 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "returns 0" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             expect(bot.inventory.refill_hand).to eq 0
@@ -873,14 +873,14 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "refills to max stack size from main inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             # Set up: 16 stone in main hand, 32 stone in main inventory
             bot.hotbar_selection = 1_u8
-            bot.chat "/item replace entity #{bot.username} hotbar.0 with minecraft:stone 16"
+            admin.item_replace "hotbar.0", "stone", 16
             bot.wait_ticks 5
-            bot.chat "/item replace entity #{bot.username} inventory.0 with minecraft:stone 32"
+            admin.item_replace "inventory.0", "stone", 32
             bot.wait_ticks 5
 
             # Test refill functionality - document current behavior
@@ -912,14 +912,14 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "refills from hotbar when main inventory is empty" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             # Set up: 10 diamond in main hand, 20 diamond in another hotbar slot, NO diamond in main inventory
             bot.hotbar_selection = 1_u8
-            bot.chat "/item replace entity #{bot.username} hotbar.0 with minecraft:diamond 10"
+            admin.item_replace "hotbar.0", "diamond", 10
             bot.wait_ticks 5
-            bot.chat "/item replace entity #{bot.username} hotbar.1 with minecraft:diamond 20"
+            admin.item_replace "hotbar.1", "diamond", 20
             bot.wait_ticks 5
 
             # Test refill_hand functionality - should combine 10 + 20 = 30 total
@@ -950,17 +950,17 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "stops at max stack size when more items are available" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             # Set up: 32 stone in main hand, 64 stone in inventory, 32 stone in hotbar
             # Total: 128 stone, but max stack is 64
             bot.hotbar_selection = 1_u8
-            bot.chat "/item replace entity #{bot.username} hotbar.0 with minecraft:stone 32"
+            admin.item_replace "hotbar.0", "stone", 32
             bot.wait_ticks 5
-            bot.chat "/item replace entity #{bot.username} inventory.0 with minecraft:stone 64"
+            admin.item_replace "inventory.0", "stone", 64
             bot.wait_ticks 5
-            bot.chat "/item replace entity #{bot.username} hotbar.1 with minecraft:stone 32"
+            admin.item_replace "hotbar.1", "stone", 32
             bot.wait_ticks 5
 
             # Test that refill stops at max stack size (64)
@@ -980,11 +980,11 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "returns current count when already at max stack" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             # Give exactly 64 stone (max stack)
-            bot.chat "/give #{bot.username} minecraft:stone 64"
+            admin.give "stone", 64
             bot.wait_ticks 5
 
             # Should return 64 without doing anything
@@ -999,13 +999,13 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "returns current count when no additional matching items exist" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             # Give 32 stone in hand and dirt in inventory (no matching items)
-            bot.chat "/give #{bot.username} minecraft:stone 32"
+            admin.give "stone", 32
             bot.wait_ticks 5
-            bot.chat "/give #{bot.username} minecraft:dirt 64"
+            admin.give "dirt", 64
             bot.wait_ticks 5
 
             # Should return current count since no more stone available
@@ -1022,19 +1022,19 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "warns and returns current quantity without refilling" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             # Teleport to known location and create chest
-            bot.chat "/tp 30.5 -60 30.5"
+            admin.tp 30.5, -60, 30.5
             bot.wait_tick
-            bot.chat "/setblock 30 -61 30 minecraft:chest"
+            admin.setblock 30, -61, 30, "chest"
             bot.wait_tick
 
             # Give stone - first to main hand, second to inventory
-            bot.chat "/give #{bot.username} minecraft:stone 32"
+            admin.give "stone", 32
             bot.wait_ticks 5
-            bot.chat "/give #{bot.username} minecraft:stone 32"
+            admin.give "stone", 32
             bot.wait_ticks 5
 
             main_hand_count_before_container = bot.inventory.main_hand.count
@@ -1066,13 +1066,13 @@ Spectator.describe "Rosegold::Bot inventory" do
       it "returns current count when item max stack is 1" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/clear"
+            admin.clear
             bot.wait_ticks 5
 
             # Give sword (non-stackable item)
-            bot.chat "/give #{bot.username} minecraft:diamond_sword 1"
+            admin.give "diamond_sword"
             bot.wait_ticks 5
-            bot.chat "/give #{bot.username} minecraft:diamond_sword 1"
+            admin.give "diamond_sword"
             bot.wait_ticks 5
 
             # Should return 1 since swords don't stack

--- a/spec/integration/movement_keys_spec.cr
+++ b/spec/integration/movement_keys_spec.cr
@@ -2,20 +2,13 @@ require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot movement keys" do
   before_all do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
-        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
-        bot.wait_tick
-      end
-    end
+    admin.setup_arena
   end
 
   it "moves forward when forward key is pressed" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 0 -60 0"
+        admin.tp 0, -60, 0
         bot.wait_tick
 
         bot.yaw = 0.0 # face south (+Z)
@@ -33,7 +26,7 @@ Spectator.describe "Rosegold::Bot movement keys" do
   it "moves backward when backward key is pressed" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 0 -60 0"
+        admin.tp 0, -60, 0
         bot.wait_tick
 
         bot.yaw = 0.0 # face south (+Z)
@@ -51,7 +44,7 @@ Spectator.describe "Rosegold::Bot movement keys" do
   it "strafes left when left key is pressed" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 0 -60 0"
+        admin.tp 0, -60, 0
         bot.wait_tick
 
         bot.yaw = 0.0 # face south (+Z), left is +X
@@ -69,7 +62,7 @@ Spectator.describe "Rosegold::Bot movement keys" do
   it "moves diagonally with two keys pressed" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 0 -60 0"
+        admin.tp 0, -60, 0
         bot.wait_ticks 3
 
         bot.yaw = 0.0 # face south
@@ -88,7 +81,7 @@ Spectator.describe "Rosegold::Bot movement keys" do
   it "stops moving after release_all" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 0 -60 0"
+        admin.tp 0, -60, 0
         bot.wait_tick
 
         bot.yaw = 0.0
@@ -109,7 +102,7 @@ Spectator.describe "Rosegold::Bot movement keys" do
   it "move_to clears movement keys on completion" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 0 -60 0"
+        admin.tp 0, -60, 0
         bot.wait_tick
 
         bot.keys.press Rosegold::MovementKeys::Key::Left

--- a/spec/integration/movement_spec.cr
+++ b/spec/integration/movement_spec.cr
@@ -2,20 +2,13 @@ require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot movement" do
   before_all do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
-        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
-        bot.wait_tick
-      end
-    end
+    admin.setup_arena
   end
 
   it "should fall due to gravity (and get held up by the ground)" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 1.5 -58 1.5"
+        admin.tp 1.5, -58, 1.5
         # Wait for teleport to take effect (bot must be above ground level)
         until bot.location.y > -59 && (bot.location.x - 1.5).abs < 0.5
           bot.wait_tick
@@ -33,7 +26,7 @@ Spectator.describe "Rosegold::Bot movement" do
   it "can move to location successfully" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 1 -60 1"
+        admin.tp 1, -60, 1
         bot.wait_tick
 
         bot.move_to 2, 2
@@ -50,7 +43,7 @@ Spectator.describe "Rosegold::Bot movement" do
     final_pitch = rand(-89..89)
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 1 -60 1"
+        admin.tp 1, -60, 1
 
         yaw = rand(-179..179)
         pitch = rand(-89..89)
@@ -78,7 +71,7 @@ Spectator.describe "Rosegold::Bot movement" do
   it "should jump and fall" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/tp 1 -60 1"
+        admin.tp 1, -60, 1
         bot.wait_tick
 
         initial_feet = bot.location
@@ -100,17 +93,17 @@ Spectator.describe "Rosegold::Bot movement" do
   describe "#move_to" do
     context "when movement is stuck" do
       it "throws Physics::MovementStuck" do
+        admin.fill 1, -60, 2, 1, -60, 2, "stone"
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
-            bot.chat "/fill 1 -60 2 1 -60 2 minecraft:stone"
-            bot.chat "/tp 1 -60 1"
+            admin.tp 1, -60, 1
             bot.wait_tick
 
             expect {
               bot.move_to 1, 2
             }.to raise_error(Rosegold::Physics::MovementStuck)
 
-            bot.chat "/fill 1 -60 2 1 -60 2 minecraft:air"
+            admin.fill 1, -60, 2, 1, -60, 2, "air"
             bot.wait_tick
           end
         end

--- a/spec/integration/movement_speed_spec.cr
+++ b/spec/integration/movement_speed_spec.cr
@@ -2,21 +2,15 @@ require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot movement speeds" do
   before_all do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
-        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
-        bot.wait_ticks 20
-      end
-    end
+    admin.setup_arena
+    admin.wait_ticks 19
   end
 
   it "should have correct movement speeds for sneak, walk, and sprint" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         bot.wait_ticks 5
-        bot.chat "/tp 0 -60 0"
+        admin.tp 0, -60, 0
         bot.wait_ticks 10
 
         bot.sneak(true)
@@ -26,7 +20,7 @@ Spectator.describe "Rosegold::Bot movement speeds" do
         sneak_time = Time.instant - start_time
         sneak_speed = 5.0 / sneak_time.total_seconds
 
-        bot.chat "/tp 0 -60 0"
+        admin.tp 0, -60, 0
         bot.wait_ticks 10
         bot.sneak(false)
         bot.wait_ticks 2
@@ -36,7 +30,7 @@ Spectator.describe "Rosegold::Bot movement speeds" do
         walk_time = Time.instant - start_time
         walk_speed = 5.0 / walk_time.total_seconds
 
-        bot.chat "/tp 0 -60 0"
+        admin.tp 0, -60, 0
         bot.wait_ticks 10
 
         bot.sprint(true)

--- a/spec/integration/sneak_edge_spec.cr
+++ b/spec/integration/sneak_edge_spec.cr
@@ -2,25 +2,17 @@ require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot sneak edge prevention" do
   before_all do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
-        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
-        bot.wait_tick
-      end
-    end
+    admin.setup_arena
   end
 
   it "should not fall off edge when sneaking" do
+    admin.fill -2, -60, -2, 4, -56, 4, "air"
+    admin.setblock 0, -57, 0, "stone"
+    admin.wait_ticks 5
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Build a 1-block pillar with air on all sides at ground level
-        bot.chat "/fill -2 -60 -2 4 -56 4 minecraft:air"
-        bot.chat "/setblock 0 -57 0 minecraft:stone"
-        bot.wait_ticks 3
-        bot.chat "/tp 0 -56 0"
-        bot.wait_tick
+        admin.tp 0, -56, 0
+        bot.wait_ticks 5
         until client.player.on_ground?
           bot.wait_tick
         end
@@ -44,14 +36,13 @@ Spectator.describe "Rosegold::Bot sneak edge prevention" do
   end
 
   it "should fall off edge when not sneaking" do
+    admin.fill -2, -60, -2, 4, -56, 4, "air"
+    admin.setblock 0, -57, 0, "stone"
+    admin.wait_ticks 5
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Same setup: 1-block pillar with air around it
-        bot.chat "/fill -2 -60 -2 4 -56 4 minecraft:air"
-        bot.chat "/setblock 0 -57 0 minecraft:stone"
-        bot.wait_ticks 3
-        bot.chat "/tp 0 -56 0"
-        bot.wait_tick
+        admin.tp 0, -56, 0
+        bot.wait_ticks 5
         until client.player.on_ground?
           bot.wait_tick
         end

--- a/spec/integration/sneaking_spec.cr
+++ b/spec/integration/sneaking_spec.cr
@@ -2,23 +2,16 @@ require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot sneaking under top half slab" do
   before_all do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-        bot.chat "/fill -10 -60 -10 10 0 10 minecraft:air"
-        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
-        bot.wait_tick
-      end
-    end
+    admin.setup_arena
   end
 
   it "should require sneaking to fit under top half slab" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         # Place a single top half slab above the player position to test clearance
-        bot.chat "/fill 0 -60 0 0 -60 2 minecraft:air"                    # Clear area
-        bot.chat "/setblock 0 -59 1 minecraft:cobblestone_slab[type=top]" # Top half slab at 1.5 blocks
-        bot.chat "/tp 0 -60 0"                                            # Start position
+        admin.fill 0, -60, 0, 0, -60, 2, "air"
+        admin.setblock 0, -59, 1, "cobblestone_slab[type=top]"
+        admin.tp 0, -60, 0
         bot.wait_tick
 
         # Without sneaking, player height (1.8) would collide with slab at 1.5 blocks
@@ -37,7 +30,7 @@ Spectator.describe "Rosegold::Bot sneaking under top half slab" do
 
         # Clean up
         bot.unsneak
-        bot.chat "/setblock 0 -59 1 minecraft:air"
+        admin.setblock 0, -59, 1, "air"
         bot.wait_tick
       end
     end

--- a/spec/integration/stairs_spec.cr
+++ b/spec/integration/stairs_spec.cr
@@ -2,28 +2,19 @@ require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot stairs movement" do
   before_all do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/kill @e[type=!minecraft:player]"
-        # Clear a test area
-        bot.chat "/fill -10 -60 -10 10 -55 10 minecraft:air"
-        # Set bedrock floor
-        bot.chat "/fill -10 -61 -10 10 -61 10 minecraft:bedrock"
-        bot.wait_tick
-      end
-    end
+    admin.kill_entities
+    admin.fill -10, -60, -10, 10, -55, 10, "air"
+    admin.fill -10, -61, -10, 10, -61, 10, "bedrock"
+    admin.wait_tick
   end
 
   it "should be able to walk up actual stone stairs" do
+    admin.setblock 1, -60, 2, "stone_stairs[facing=south]"
+    admin.setblock 1, -60, 3, "stone"
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        bot.chat "/setblock 1 -60 2 minecraft:stone_stairs[facing=south]" # Actual stairs facing north
-        bot.chat "/setblock 1 -60 3 minecraft:stone"                      # Destination block (one level up)
-
-        bot.wait_tick
-
-        # Start the bot at 1,1
-        bot.chat "/tp 1 -60 1"
+        admin.tp 1, -60, 1
         bot.wait_tick
 
         initial_y = bot.location.y

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,6 @@
 require "../src/rosegold"
 require "spectator"
+require "./support/admin_bot"
 
 MC_TEST_HOST = ENV["MC_TEST_HOST"]? || "localhost"
 MC_TEST_PORT = (ENV["MC_TEST_PORT"]? || "25565").to_i
@@ -7,6 +8,12 @@ MC_TEST_PORT = (ENV["MC_TEST_PORT"]? || "25565").to_i
 def client
   Rosegold::Client.new(MC_TEST_HOST, MC_TEST_PORT, offline: {uuid: "00000000-0000-0000-0000-000000000000", username: "rosegoldtest"})
 end
+
+def admin
+  AdminBot.lazy_instance(MC_TEST_HOST, MC_TEST_PORT)
+end
+
+at_exit { AdminBot.shutdown }
 
 Spectator.configure do |config|
   config.formatter = Spectator::Formatting::DocumentFormatter.new

--- a/spec/support/admin_bot.cr
+++ b/spec/support/admin_bot.cr
@@ -1,0 +1,142 @@
+class AdminBot
+  TEST_PLAYER = "rosegoldtest"
+
+  @@instance : AdminBot? = nil
+
+  def self.lazy_instance(host, port)
+    @@instance ||= new(host, port).connect
+  end
+
+  def self.shutdown
+    @@instance.try &.disconnect
+  end
+
+  getter bot : Rosegold::Bot
+  getter client : Rosegold::Client
+  @host : String
+  @port : Int32
+
+  def initialize(@host, @port)
+    @client = create_client
+    @bot = Rosegold::Bot.new(@client)
+  end
+
+  def connect
+    @client.join_game
+    setup_disconnect_handler
+    self
+  end
+
+  def disconnect
+    @client.connection?.try &.disconnect("AdminBot shutdown")
+  end
+
+  def connected?
+    @client.connected?
+  end
+
+  def chat(command : String)
+    ensure_connected
+    @bot.chat command
+  end
+
+  def wait_ticks(n)
+    ensure_connected
+    @bot.wait_ticks(n)
+  end
+
+  def wait_tick
+    ensure_connected
+    @bot.wait_tick
+  end
+
+  def setup_arena
+    kill_entities
+    fill(-10, -60, -10, 10, 0, 10, "air")
+    fill(-10, -61, -10, 10, -61, 10, "bedrock")
+    wait_tick
+  end
+
+  def tp(target : String, x, y, z)
+    chat "/tp #{target} #{x} #{y} #{z}"
+  end
+
+  def tp(x, y, z)
+    tp(TEST_PLAYER, x, y, z)
+  end
+
+  def fill(x1, y1, z1, x2, y2, z2, block : String)
+    chat "/fill #{x1} #{y1} #{z1} #{x2} #{y2} #{z2} minecraft:#{block}"
+  end
+
+  def setblock(x, y, z, block : String, mode : String? = nil)
+    cmd = "/setblock #{x} #{y} #{z} minecraft:#{block}"
+    cmd += " #{mode}" if mode
+    chat cmd
+  end
+
+  def item_replace(slot : String, item : String, count = 1)
+    chat "/item replace entity #{TEST_PLAYER} #{slot} with minecraft:#{item} #{count}"
+  end
+
+  def give(target : String, item : String, count = 1)
+    chat "/give #{target} #{item} #{count}"
+  end
+
+  def give(item : String, count = 1)
+    give(TEST_PLAYER, item, count)
+  end
+
+  def clear(target = TEST_PLAYER)
+    chat "/clear #{target}"
+  end
+
+  def kill_entities
+    chat "/kill @e[type=!minecraft:player]"
+  end
+
+  def effect_give(target : String, effect : String, duration = 60, amplifier = 0)
+    chat "/effect give #{target} minecraft:#{effect} #{duration} #{amplifier}"
+  end
+
+  def effect_give(effect : String, duration = 60, amplifier = 0)
+    effect_give(TEST_PLAYER, effect, duration, amplifier)
+  end
+
+  def effect_clear(target = TEST_PLAYER)
+    chat "/effect clear #{target}"
+  end
+
+  def time_set(value)
+    chat "/time set #{value}"
+  end
+
+  def summon(entity : String, x, y, z)
+    chat "/summon minecraft:#{entity} #{x} #{y} #{z}"
+  end
+
+  private def create_client
+    Rosegold::Client.new(@host, @port, offline: {
+      uuid:     "ac05f26e-c3db-3f24-898e-263087468b84",
+      username: "rosegoldadmin",
+    })
+  end
+
+  private def ensure_connected
+    return if connected?
+    reconnect
+  end
+
+  private def reconnect
+    @client = create_client
+    @bot = Rosegold::Bot.new(@client)
+    @client.join_game
+    setup_disconnect_handler
+  end
+
+  private def setup_disconnect_handler
+    @client.on(Rosegold::Event::Disconnected) do |_event|
+      Log.warn { "AdminBot disconnected, will reconnect on next command" }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Introduces a persistent `AdminBot` (rosegoldadmin) that connects once at suite start and handles all setup commands (`/tp`, `/fill`, `/give`, `/kill`, `/clear`, `/effect`, `/time`, `/summon`, `/setblock`) across the entire test run
- Eliminates extra connect/disconnect cycles in `before_all` blocks and inline `it` block setup across 15 integration specs
- Adds `OPS` env var to docker-compose for reliable op provisioning on server init

## Test plan
- [x] All 480 integration tests pass (`crystal spec`)
- [x] All 20 spec files compile cleanly (`crystal build --no-codegen`)
- [x] Verify docker server restart picks up rosegoldadmin in ops