### PR TITLE
Fix physics accuracy for reach, gravity, step-up

### DIFF
--- a/src/rosegold/control/interactions.cr
+++ b/src/rosegold/control/interactions.cr
@@ -265,7 +265,7 @@ class Rosegold::Interactions
   end
 
   private def reach_entity : Rosegold::Entity?
-    client.dimension.raycast_entity client.player.eyes, reach_vec, reach_length
+    client.dimension.raycast_entity client.player.eyes, entity_reach_vec, entity_reach_length
   end
 
   # Unified raytracing that properly handles both entities and blocks
@@ -307,18 +307,28 @@ class Rosegold::Interactions
       block = block_boxes[result.box_nr].min.block
       ReachedBlock.new result.intercept, block, result.face
     else
-      # Hit an entity
+      # Hit an entity - check if within entity reach distance
+      hit_distance = (result.intercept - eyes).length
+      return nil if hit_distance > entity_reach_length
       entity_index = result.box_nr - block_count
       entity_map[entity_index]
     end
   end
 
-  private def reach_length
+  private def block_reach_length
     client.player.gamemode == 1 ? 5.0 : 4.5
   end
 
+  private def entity_reach_length
+    client.player.gamemode == 1 ? 5.0 : 3.0
+  end
+
   private def reach_vec
-    client.player.look.to_vec3 * reach_length
+    client.player.look.to_vec3 * block_reach_length
+  end
+
+  private def entity_reach_vec
+    client.player.look.to_vec3 * entity_reach_length
   end
 
   # Returns all block collision boxes that may intersect from `start` towards `reach`.

--- a/src/rosegold/control/physics.cr
+++ b/src/rosegold/control/physics.cr
@@ -408,6 +408,10 @@ class Rosegold::Physics
     movement, post_collision_velocity = Physics.predict_movement_collision(
       player.feet, input_velocity, current_player_aabb, dimension)
 
+    # Apply gravity AFTER collision, matching Minecraft's LivingEntity.travel() order:
+    # 1. moveRelative (input) → 2. move (collision) → 3. gravity → 4. drag
+    post_collision_velocity = post_collision_velocity - Vec3d.new(0, GRAVITY, 0)
+
     if player.on_ground?
       slip = block_slip
       drag_factor = slip * 0.91
@@ -487,7 +491,7 @@ class Rosegold::Physics
 
               JUMP_FORCE
             else
-              combined_velocity.y - 0.08
+              combined_velocity.y
             end
 
     horiz_length = Vec3d.new(combined_velocity.x, 0, combined_velocity.z).length
@@ -724,7 +728,7 @@ class Rosegold::Physics
     collided_z = (movement.z - velocity.z).abs > EPSILON_COLLISION
 
     if collided_x || collided_z
-      step_up_movement = slide start, Vec3d.new(0, 0.5, 0), obstacles
+      step_up_movement = slide start, Vec3d.new(0, MAX_UP_STEP, 0), obstacles
       step_up = start + step_up_movement
       # gravity would pull us into the step, preventing stepping
       over_velocity = velocity.with_y 0
@@ -778,8 +782,8 @@ class Rosegold::Physics
       entity_aabb.offset(start + movement))
     # fences are 1.5m tall
     min_block = bounds.min.down(0.5).block
-    # add maximum stepping height (0.5) so we can reuse the obstacles when stepping
-    max_block = bounds.max.up(0.5).block
+    # add maximum stepping height so we can reuse the obstacles when stepping
+    max_block = bounds.max.up(MAX_UP_STEP).block
     blocks_coords = Indexable.cartesian_product({
       (min_block.x..max_block.x).to_a,
       (min_block.y..max_block.y).to_a,


### PR DESCRIPTION
## Summary
- Separate block reach (4.5) from entity reach (3.0) to match Minecraft's distinct interaction ranges — prevents anti-cheat triggers on strict servers
- Apply gravity after collision instead of before, matching LivingEntity.travelInAir() order: input → collision → gravity → drag
- Replace hardcoded 0.5 step-up with MAX_UP_STEP (0.6) in both step-up slide and obstacle search bounds

## Verification
- All values confirmed against decompiled Minecraft 1.21.8 source (Player.java, Attributes.java, LivingEntity.java, Entity.java)
- Reviewed by dedicated minecraft-expert agent and Crystal code quality reviewer

## Test plan
- [ ] Bot can walk up 1-block steps without getting stuck
- [ ] Bot does not hit entities beyond 3.0 blocks in survival
- [ ] Falling behavior matches vanilla timing