### PR TITLE
Use VarInt for entity IDs in all packets

### DIFF
--- a/src/rosegold/packets/clientbound/destroy_entities.cr
+++ b/src/rosegold/packets/clientbound/destroy_entities.cr
@@ -14,11 +14,7 @@ class Rosegold::Clientbound::DestroyEntities < Rosegold::Clientbound::Packet
   def self.read(packet)
     entity_ids = [] of UInt64
     count = packet.read_var_int
-    if Client.protocol_version >= 774_u32
-      count.times { entity_ids << packet.read_var_int.to_u64 }
-    else
-      count.times { entity_ids << packet.read_var_long }
-    end
+    count.times { entity_ids << packet.read_var_int.to_u64 }
     self.new entity_ids
   end
 
@@ -26,11 +22,7 @@ class Rosegold::Clientbound::DestroyEntities < Rosegold::Clientbound::Packet
     Minecraft::IO::Memory.new.tap do |buffer|
       buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
       buffer.write entity_ids.size
-      if Client.protocol_version >= 774_u32
-        entity_ids.each { |entity_id| buffer.write entity_id.to_u32 }
-      else
-        entity_ids.each { |entity_id| buffer.write entity_id }
-      end
+      entity_ids.each { |entity_id| buffer.write entity_id.to_u32 }
     end.to_slice
   end
 

--- a/src/rosegold/packets/clientbound/entity_effect.cr
+++ b/src/rosegold/packets/clientbound/entity_effect.cr
@@ -17,11 +17,7 @@ class Rosegold::Clientbound::EntityEffect < Rosegold::Clientbound::Packet
   def initialize(@entity_id, @effect_id, @amplifier, @duration, @flags); end
 
   def self.read(packet)
-    if Client.protocol_version >= 774_u32
-      entity_id = packet.read_var_int.to_u64
-    else
-      entity_id = packet.read_var_long
-    end
+    entity_id = packet.read_var_int.to_u64
     effect_id = packet.read_var_int
     amplifier = packet.read_var_int
     duration = packet.read_var_int
@@ -33,11 +29,7 @@ class Rosegold::Clientbound::EntityEffect < Rosegold::Clientbound::Packet
   def write : Bytes
     Minecraft::IO::Memory.new.tap do |buffer|
       buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
-      if Client.protocol_version >= 774_u32
-        buffer.write entity_id.to_u32
-      else
-        buffer.write entity_id
-      end
+      buffer.write entity_id.to_u32
       buffer.write effect_id
       buffer.write amplifier
       buffer.write duration

--- a/src/rosegold/packets/clientbound/entity_position.cr
+++ b/src/rosegold/packets/clientbound/entity_position.cr
@@ -18,11 +18,7 @@ class Rosegold::Clientbound::EntityPosition < Rosegold::Clientbound::Packet
   end
 
   def self.read(packet)
-    if Client.protocol_version >= 774_u32
-      entity_id = packet.read_var_int.to_u64
-    else
-      entity_id = packet.read_var_long
-    end
+    entity_id = packet.read_var_int.to_u64
     delta_x = packet.read_short
     delta_y = packet.read_short
     delta_z = packet.read_short
@@ -34,11 +30,7 @@ class Rosegold::Clientbound::EntityPosition < Rosegold::Clientbound::Packet
   def write : Bytes
     Minecraft::IO::Memory.new.tap do |buffer|
       buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
-      if Client.protocol_version >= 774_u32
-        buffer.write entity_id.to_u32
-      else
-        buffer.write entity_id
-      end
+      buffer.write entity_id.to_u32
       buffer.write delta_x
       buffer.write delta_y
       buffer.write delta_z

--- a/src/rosegold/packets/clientbound/entity_position_and_rotation.cr
+++ b/src/rosegold/packets/clientbound/entity_position_and_rotation.cr
@@ -20,11 +20,7 @@ class Rosegold::Clientbound::EntityPositionAndRotation < Rosegold::Clientbound::
   end
 
   def self.read(packet)
-    if Client.protocol_version >= 774_u32
-      entity_id = packet.read_var_int.to_u64
-    else
-      entity_id = packet.read_var_long
-    end
+    entity_id = packet.read_var_int.to_u64
     delta_x = packet.read_short
     delta_y = packet.read_short
     delta_z = packet.read_short
@@ -38,11 +34,7 @@ class Rosegold::Clientbound::EntityPositionAndRotation < Rosegold::Clientbound::
   def write : Bytes
     Minecraft::IO::Memory.new.tap do |buffer|
       buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
-      if Client.protocol_version >= 774_u32
-        buffer.write entity_id.to_u32
-      else
-        buffer.write entity_id
-      end
+      buffer.write entity_id.to_u32
       buffer.write delta_x
       buffer.write delta_y
       buffer.write delta_z

--- a/src/rosegold/packets/clientbound/entity_position_sync.cr
+++ b/src/rosegold/packets/clientbound/entity_position_sync.cr
@@ -25,11 +25,7 @@ class Rosegold::Clientbound::EntityPositionSync < Rosegold::Clientbound::Packet
   end
 
   def self.read(packet)
-    if Client.protocol_version >= 774_u32
-      entity_id = packet.read_var_int.to_u64
-    else
-      entity_id = packet.read_var_long
-    end
+    entity_id = packet.read_var_int.to_u64
     x = packet.read_double
     y = packet.read_double
     z = packet.read_double
@@ -46,11 +42,7 @@ class Rosegold::Clientbound::EntityPositionSync < Rosegold::Clientbound::Packet
   def write : Bytes
     Minecraft::IO::Memory.new.tap do |buffer|
       buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
-      if Client.protocol_version >= 774_u32
-        buffer.write entity_id.to_u32
-      else
-        buffer.write entity_id
-      end
+      buffer.write entity_id.to_u32
       buffer.write_full x
       buffer.write_full y
       buffer.write_full z

--- a/src/rosegold/packets/clientbound/entity_rotation.cr
+++ b/src/rosegold/packets/clientbound/entity_rotation.cr
@@ -17,11 +17,7 @@ class Rosegold::Clientbound::EntityRotation < Rosegold::Clientbound::Packet
   end
 
   def self.read(packet)
-    if Client.protocol_version >= 774_u32
-      entity_id = packet.read_var_int.to_u64
-    else
-      entity_id = packet.read_var_long
-    end
+    entity_id = packet.read_var_int.to_u64
     yaw = packet.read_angle256_deg
     pitch = packet.read_angle256_deg
     on_ground = packet.read_bool
@@ -32,11 +28,7 @@ class Rosegold::Clientbound::EntityRotation < Rosegold::Clientbound::Packet
   def write : Bytes
     Minecraft::IO::Memory.new.tap do |buffer|
       buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
-      if Client.protocol_version >= 774_u32
-        buffer.write entity_id.to_u32
-      else
-        buffer.write entity_id
-      end
+      buffer.write entity_id.to_u32
       buffer.write_angle256_deg yaw
       buffer.write_angle256_deg pitch
       buffer.write on_ground?

--- a/src/rosegold/packets/clientbound/remove_entity_effect.cr
+++ b/src/rosegold/packets/clientbound/remove_entity_effect.cr
@@ -14,11 +14,7 @@ class Rosegold::Clientbound::RemoveEntityEffect < Rosegold::Clientbound::Packet
   def initialize(@entity_id, @effect_id); end
 
   def self.read(packet)
-    if Client.protocol_version >= 774_u32
-      entity_id = packet.read_var_int.to_u64
-    else
-      entity_id = packet.read_var_long
-    end
+    entity_id = packet.read_var_int.to_u64
     effect_id = packet.read_var_int
 
     self.new(entity_id, effect_id)


### PR DESCRIPTION
## Summary
- Remove unnecessary version branching that used read_var_long for protocol 772
- Entity IDs are VarInt in both protocol 772 (1.21.8) and 774 (1.21.11)
- Affects 7 packets: entity position, position+rotation, rotation, position sync, effect, remove effect, destroy entities

## Verification
- Confirmed against decompiled Minecraft 1.21.8 source: ClientboundMoveEntityPacket, RemoveEntitiesPacket, EntityPositionSyncPacket, UpdateMobEffectPacket all use writeVarInt/readVarInt
- Independently verified by 3 separate minecraft-expert agents + tiebreaker with Java source evidence

## Test plan
- [ ] Entity tracking works correctly on 1.21.8 servers
- [ ] Entity tracking works correctly on 1.21.11 servers