### PR TITLE
Fix ClientInformation packet fields

### DIFF
--- a/src/rosegold/packets/serverbound/client_information.cr
+++ b/src/rosegold/packets/serverbound/client_information.cr
@@ -13,30 +13,33 @@ class Rosegold::Serverbound::ClientInformation < Rosegold::Serverbound::Packet
   property \
     locale : String,
     view_distance : UInt8,
-    chat_mode : UInt8,
+    chat_mode : UInt32,
     chat_colors : Bool,
     displayed_skin_parts : UInt8,
-    main_hand : UInt8,
+    main_hand : UInt32,
     enable_text_filtering : Bool,
-    allow_server_listings : Bool
+    allow_server_listings : Bool,
+    particle_status : UInt32
 
-  def initialize(@locale = "en_US", @view_distance = 10_u8, @chat_mode = 0_u8,
-                 @chat_colors = true, @displayed_skin_parts = 0x7F_u8, @main_hand = 1_u8,
-                 @enable_text_filtering = false, @allow_server_listings = true)
+  def initialize(@locale = "en_US", @view_distance = 10_u8, @chat_mode = 0_u32,
+                 @chat_colors = true, @displayed_skin_parts = 0x7F_u8, @main_hand = 1_u32,
+                 @enable_text_filtering = false, @allow_server_listings = true,
+                 @particle_status = 0_u32)
   end
 
   def self.read(packet)
     locale = packet.read_var_string
     view_distance = packet.read_byte || 0_u8
-    chat_mode = packet.read_byte || 0_u8
+    chat_mode = packet.read_var_int
     chat_colors = packet.read_bool
     displayed_skin_parts = packet.read_byte || 0_u8
-    main_hand = packet.read_byte || 0_u8
+    main_hand = packet.read_var_int
     enable_text_filtering = packet.read_bool
     allow_server_listings = packet.read_bool
+    particle_status = packet.read_var_int
 
     self.new(locale, view_distance, chat_mode, chat_colors, displayed_skin_parts,
-      main_hand, enable_text_filtering, allow_server_listings)
+      main_hand, enable_text_filtering, allow_server_listings, particle_status)
   end
 
   def write : Bytes
@@ -50,6 +53,7 @@ class Rosegold::Serverbound::ClientInformation < Rosegold::Serverbound::Packet
       buffer.write main_hand
       buffer.write enable_text_filtering
       buffer.write allow_server_listings
+      buffer.write particle_status
     end.to_slice
   end
 end


### PR DESCRIPTION
## Summary
- Change chat_mode and main_hand from raw byte (UInt8) to VarInt (UInt32) to match protocol spec
- Add missing particle_status field (VarInt Enum, default 0=all) required since 1.21.2
- Without this fix the packet is shorter than servers expect

## Verification
- Confirmed against decompiled ClientInformation.java: chatVisibility, mainHand, and particleStatus all use readEnum() which calls readVarInt()
- Field order verified: all 9 fields present in correct sequence
- Reviewed by dedicated minecraft-expert agent

## Test plan
- [ ] Client connects successfully to 1.21.8 and 1.21.11 servers
- [ ] Server does not log warnings about malformed ClientInformation