### PR TITLE
Fix ClickWindow state_id truncation

### DIFF
--- a/src/rosegold/packets/serverbound/click_window.cr
+++ b/src/rosegold/packets/serverbound/click_window.cr
@@ -89,6 +89,6 @@ class Rosegold::Serverbound::ClickWindow < Rosegold::Serverbound::Packet
   private def self.new(mode : Mode, button, slot_number, window)
     changed_slots = [] of WindowSlot # TODO
     self.new mode, button.to_i8, slot_number.to_i16,
-      changed_slots, window.id.to_u8, window.state_id.to_i16, window.cursor
+      changed_slots, window.id.to_u8, window.state_id.to_i32, window.cursor
   end
 end


### PR DESCRIPTION
## Summary
- The private constructor called `window.state_id.to_i16`, truncating the 32-bit VarInt state_id to 16 bits
- After 32K inventory operations the state_id wraps and servers reject clicks
- Fix: use `.to_i32` to preserve the full range

## Verification
- Confirmed against decompiled ServerboundContainerClickPacket.java: stateId is `int` (32-bit), encoded as VAR_INT
- Reviewed by dedicated minecraft-expert agent

## Test plan
- [ ] Inventory clicks work in long-running bot sessions (32K+ operations)