### PR TITLE
Fix tick rate and air block detection

### DIFF
--- a/src/rosegold/client.cr
+++ b/src/rosegold/client.cr
@@ -129,11 +129,11 @@ class Rosegold::Client < Rosegold::EventEmitter
   end
 
   # Calculate tick interval based on current tick rate
+  # Vanilla client never ticks faster than 20 TPS (Minecraft.java:getTickTargetMillis)
   def tick_interval : Time::Span
-    # Convert TPS to milliseconds per tick
-    # 20 TPS = 50ms per tick, so: 1000ms / tick_rate
-    millis_per_tick = (1000.0 / @tick_rate).to_i
-    millis_per_tick.milliseconds
+    rate = @tick_rate > 0 ? @tick_rate : 20.0_f32
+    millis_per_tick = (1000.0 / rate).to_i
+    {millis_per_tick.milliseconds, 50.milliseconds}.max
   end
 
   def average_millis_per_chunk : Float64
@@ -226,29 +226,25 @@ class Rosegold::Client < Rosegold::EventEmitter
   def start_ticker
     @ticker_done = Channel(Nil).new
     spawn do
-      target_interval_ns = 50_000_000_u64
-      tick_counter = 0_u64
-
-      start_time = Time.instant
+      next_tick_time = Time.instant
 
       loop do
         break unless connected?
 
-        target_elapsed_ns = tick_counter * target_interval_ns
-        current_elapsed_ns = (Time.instant - start_time).total_nanoseconds.to_u64
+        next_tick_time = {next_tick_time + tick_interval, Time.instant}.max
 
-        if current_elapsed_ns < target_elapsed_ns
-          sleep_ns = target_elapsed_ns - current_elapsed_ns
+        if Time.instant < next_tick_time
+          remaining_ns = (next_tick_time - Time.instant).total_nanoseconds.to_i64
 
-          if sleep_ns > 1_000_000
-            rough_sleep_ns = sleep_ns - 500_000
-            sleep Time::Span.new(nanoseconds: rough_sleep_ns.to_i64)
+          if remaining_ns > 1_000_000
+            rough_sleep_ns = remaining_ns - 500_000
+            sleep Time::Span.new(nanoseconds: rough_sleep_ns)
 
-            while (Time.instant - start_time).total_nanoseconds.to_u64 < target_elapsed_ns
+            while Time.instant < next_tick_time
               Fiber.yield
             end
           else
-            while (Time.instant - start_time).total_nanoseconds.to_u64 < target_elapsed_ns
+            while Time.instant < next_tick_time
               Fiber.yield
             end
           end
@@ -276,14 +272,8 @@ class Rosegold::Client < Rosegold::EventEmitter
           end
         end
 
-        tick_counter += 1
-
-        if tick_counter % 100 == 0
-          actual_elapsed_ns = (Time.instant - start_time).total_nanoseconds.to_u64
-          expected_elapsed_ns = tick_counter * target_interval_ns
-          drift_ms = (actual_elapsed_ns.to_i64 - expected_elapsed_ns.to_i64) / 1_000_000.0
-          Log.trace { "Tick #{tick_counter}: drift #{drift_ms.round(2)}ms" }
-        end
+        drift_ms = (Time.instant - next_tick_time).total_nanoseconds / 1_000_000.0
+        Log.trace { "Tick drift: #{drift_ms.round(2)}ms (rate: #{@tick_rate} TPS)" } if drift_ms.abs > 5
       end
 
       @ticker_done.send nil

--- a/src/rosegold/world/chunk.cr
+++ b/src/rosegold/world/chunk.cr
@@ -41,7 +41,7 @@ class Rosegold::Chunk
     section = sections[section_index]
 
     # Java client optimization: if setting air to air in an air-only section, return nil
-    if section.has_only_air? && block_state == 0_u16
+    if section.has_only_air? && MCData.default.air_states.includes?(block_state)
       return nil
     end
 

--- a/src/rosegold/world/mcdata.cr
+++ b/src/rosegold/world/mcdata.cr
@@ -32,6 +32,9 @@ class Rosegold::MCData
   # block state nr -> "oak_slab[type=top, waterlogged=true]"
   getter block_state_names : Array(String)
 
+  # Set of block state IDs that are air (air, cave_air, void_air)
+  getter air_states : Set(UInt16)
+
   # block state nr -> array of AABBs that combine to make up that block state shape
   # TODO: more compact memory layout: only store one Shape if it's the same for all variants of a block
   getter block_state_collision_shapes : Array(Array(AABBf))
@@ -74,6 +77,13 @@ class Rosegold::MCData
     block_collision_shapes_json = BlockCollisionShapes.from_json(collision_shapes_json)
 
     max_block_state = blocks.flat_map(&.max_state_id).max
+
+    @air_states = Set(UInt16).new
+    blocks.each do |block|
+      if block.id_str.in?("air", "cave_air", "void_air")
+        (block.min_state_id..block.max_state_id).each { |state| @air_states << state }
+      end
+    end
 
     @block_state_names = Array(String).new(max_block_state + 1, "")
     blocks.each do |block|

--- a/src/rosegold/world/section.cr
+++ b/src/rosegold/world/section.cr
@@ -40,11 +40,12 @@ class Rosegold::Section
     previous_state = @blocks[index]
     @blocks[index] = block_state
 
-    # Update block count based on air transitions (0 = air)
-    if previous_state != 0_u16 # was not air
+    # Update block count based on air transitions (air, cave_air, void_air)
+    air_states = MCData.default.air_states
+    if !air_states.includes?(previous_state) # was not air
       @block_count -= 1
     end
-    if block_state != 0_u16 # is not air
+    if !air_states.includes?(block_state) # is not air
       @block_count += 1
     end
 


### PR DESCRIPTION
## Summary
- Use dynamic tick interval from server tick_rate instead of hardcoded 50ms — the `tick_interval` method already existed but was never called
- Detect cave_air and void_air as air blocks in section block counting, not just state 0
- Guard against division-by-zero when tick_rate is 0 (SpectateServer sends this)

## Verification
- Confirmed against decompiled Minecraft 1.21.8: `TickRateManager.java` default 20.0 TPS, `Blocks.java` confirms exactly 3 air blocks (air, cave_air, void_air), `LevelChunkSection.java` uses `isAir()` for all 3
- Reviewed by dedicated minecraft-expert agent and Crystal code quality reviewer

## Test plan
- [ ] Bot respects server tick rate changes (e.g., `/tick rate 10`)
- [ ] Sections containing only cave_air report `has_only_air?` correctly