### PR TITLE
Speed up integration test suite (~3:40 → ~2:13)

### DIFF
--- a/spec/integration/attack_spec.cr
+++ b/spec/integration/attack_spec.cr
@@ -7,33 +7,31 @@ end
 Spectator.describe "Rosegold::Bot attack" do
   after_all do
     admin.setup_arena
-    admin.wait_ticks 4
+    admin.wait_tick
   end
 
   it "should be able to attack even if the target is moving" do
     admin.setup_arena
-    admin.wait_ticks 19
+    admin.wait_ticks 5
     admin.time_set 13000
     admin.fill -10, -60, 8, 0, -58, 6, "obsidian"
     admin.fill -9, -60, 7, 0, -58, 7, "air"
-    admin.wait_ticks 5
+    admin.wait_tick
     admin.fill -6, -60, 7, -6, -60, 7, "water"
     admin.wait_tick
     admin.fill -9, -59, 8, -9, -59, 8, "air"
     admin.wait_tick
     admin.chat "/kill @e[type=zombie]"
-    admin.wait_ticks 10
+    admin.wait_tick
     admin.summon "zombie", -7, -60, 7
-    admin.wait_ticks 10
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.tp -9, -60, 9
         admin.clear
-        admin.wait_ticks 5
         admin.give "diamond_sword[enchantments={\"minecraft:sharpness\":5}]"
-        admin.wait_ticks 5
         admin.effect_give "strength", 60, 2
-        admin.wait_ticks 5
+        bot.wait_ticks 5
 
         bot.inventory.pick! "diamond_sword"
         bot.yaw = 180
@@ -58,26 +56,24 @@ Spectator.describe "Rosegold::Bot attack" do
 
   it "should not be able to attack entities through blocks" do
     admin.setup_arena
-    admin.wait_ticks 19
+    admin.wait_ticks 5
     admin.time_set 13000
     admin.fill -10, -60, 8, 0, -58, 6, "obsidian"
     admin.fill -9, -60, 7, 0, -58, 7, "air"
-    admin.wait_ticks 5
+    admin.wait_tick
     admin.fill -6, -60, 7, -6, -60, 7, "water"
     admin.wait_tick
     admin.chat "/kill @e[type=zombie]"
-    admin.wait_ticks 5
+    admin.wait_tick
     admin.summon "zombie", -7, -60, 7
-    admin.wait_ticks 5
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.tp -9, -60, 9
         admin.clear
-        admin.wait_ticks 5
         admin.give "diamond_sword[enchantments={\"minecraft:sharpness\":5}]"
-        admin.wait_ticks 5
         admin.effect_give "strength", 60, 2
-        admin.wait_ticks 5
+        bot.wait_ticks 5
         bot.inventory.pick! "diamond_sword"
 
         # Aim towards the zombie (south, towards negative Z)

--- a/spec/integration/button_spec.cr
+++ b/spec/integration/button_spec.cr
@@ -6,9 +6,9 @@ Spectator.describe "Rosegold::Bot button interactions" do
   end
   it "should be able to push a stone button on the ground" do
     admin.fill 5, -61, 5, 7, -59, 5, "air"
-    admin.wait_ticks 5
+    admin.wait_tick
     admin.setblock 5, -61, 5, "stone_button[face=floor]"
-    admin.wait_ticks 5
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.tp 5.5, -60, 5.5
@@ -51,7 +51,7 @@ Spectator.describe "Rosegold::Bot button interactions" do
   it "should be able to push a stone button on the wall" do
     admin.setblock 3, -60, 3, "stone"
     admin.setblock 4, -60, 3, "stone_button[face=wall,facing=east]"
-    admin.wait_ticks 5
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.tp 5, -60, 3.5

--- a/spec/integration/chat_spec.cr
+++ b/spec/integration/chat_spec.cr
@@ -1,137 +1,53 @@
 require "../spec_helper"
 
 Spectator.describe "Rosegold::Bot chat functionality" do
-  it "should be able to send basic chat messages" do
+  it "should send chat messages and commands without error" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
-        # Send a simple chat message
-        bot.chat "Hello from integration test!"
-        bot.wait_ticks 5 # Wait for message to be processed
-
-        # The test passes if no exception is thrown during chat
-        expect(true).to be_true
-      end
-    end
-  end
-
-  it "should be able to send chat commands" do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        # Send a command via chat
-        bot.chat "/time query daytime"
-        bot.wait_ticks 5 # Wait for command to be processed
-
-        # The test passes if no exception is thrown during command
-        expect(true).to be_true
-      end
-    end
-  end
-
-  it "should handle different message lengths" do
-    client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        # Test short message
         bot.chat "Hi!"
-        bot.wait_ticks 2
-
-        # Test medium message
         bot.chat "This is a medium length message for testing purposes."
+        bot.chat "A" * 100
+        bot.chat "/time query daytime"
         bot.wait_ticks 2
 
-        # Test long message (but under 256 character limit)
-        long_message = "A" * 100
-        bot.chat long_message
-        bot.wait_ticks 5
-
-        expect(true).to be_true
+        expect(client.connected?).to be_true
       end
     end
   end
 
-  it "should receive System Chat Message packets (0x72)" do
-    client.join_game do |client|
-      received_system_chat = false
-
-      # Listen specifically for System Chat Message packets
-      client.on(Rosegold::Clientbound::SystemChatMessage) do |_|
-        received_system_chat = true
-      end
-
-      Rosegold::Bot.new(client).try do |bot|
-        # Commands that typically generate system chat messages
-        # /time query should generate a system response
-        bot.chat "/time query daytime"
-        bot.wait_ticks 10
-
-        # For now, just verify the packet type can be handled without errors
-        # System chat messages may not always be generated depending on server config
-        expect(true).to be_true
-      end
-    end
-  end
-
-  it "should receive Player Chat Message packets (0x3A)" do
-    client.join_game do |client|
-      received_player_chat = false
-
-      # Listen specifically for Player Chat Message packets
-      client.on(Rosegold::Clientbound::PlayerChatMessage) do |_|
-        received_player_chat = true
-      end
-
-      Rosegold::Bot.new(client).try do |bot|
-        # Regular chat messages between players should generate PlayerChatMessage packets
-        # Since we're testing alone, we won't receive player messages
-        # But we can verify the packet handler is set up correctly
-        bot.chat "Hello world!"
-        bot.wait_ticks 5
-
-        # Test passes if no packet parsing errors occur
-        expect(true).to be_true
-      end
-    end
-  end
-
-  it "should receive Disguised Chat Message packets (0x1D)" do
+  it "should receive Disguised Chat Message packets" do
     client.join_game do |client|
       received_disguised_chat = false
 
-      # Listen specifically for Disguised Chat Message packets
       client.on(Rosegold::Clientbound::DisguisedChatMessage) do |_|
         received_disguised_chat = true
       end
 
       Rosegold::Bot.new(client).try do |bot|
-        # /say command should generate a DisguisedChatMessage packet
         bot.chat "/say Test message from server"
         bot.wait_ticks 10
-
-        # Verify we received the disguised chat message
-        expect(received_disguised_chat).to be_true
       end
+
+      expect(received_disguised_chat).to be_true
     end
   end
 
-  it "should handle chat message packet structure correctly" do
+  it "should receive System Chat Message packets with correct structure" do
     client.join_game do |client|
-      message_received = false
+      received_packet : Rosegold::Clientbound::SystemChatMessage? = nil
 
-      # Monitor for any chat-related packets
       client.on(Rosegold::Clientbound::SystemChatMessage) do |packet|
-        message_received = true
-        # Verify packet structure
-        expect(packet.message).to be_a(Rosegold::TextComponent)
-        expect(packet.overlay?).to be_a(Bool)
+        received_packet ||= packet
       end
 
       Rosegold::Bot.new(client).try do |bot|
-        # Trigger a server message
-        bot.chat "/me is testing chat functionality"
+        bot.chat "/time query daytime"
         bot.wait_ticks 10
-
-        # At minimum, no packet decode errors should occur
-        expect(true).to be_true
       end
+
+      expect(received_packet).to_not be_nil
+      expect(received_packet.try(&.message)).to be_a(Rosegold::TextComponent)
+      expect(received_packet.try(&.overlay?)).to be_a(Bool)
     end
   end
 end

--- a/spec/integration/chunk_batch_spec.cr
+++ b/spec/integration/chunk_batch_spec.cr
@@ -3,12 +3,10 @@ require "../spec_helper"
 Spectator.describe "Chunk Batch Timing Integration" do
   it "should handle chunk batch timing correctly" do
     client.join_game do |client|
-      Rosegold::Bot.new(client).try do |bot|
-        admin.tp 100, -60, 100
-        bot.wait_tick
-
-        # Wait a bit for chunk batches to be processed
-        sleep 2.seconds
+      Rosegold::Bot.new(client).try do |_bot|
+        client.wait_for(Rosegold::Clientbound::ChunkBatchFinished, timeout: 3.seconds) do
+          admin.tp 100, -60, 100
+        end
 
         # Check that chunk batch samples were collected
         expect(client.chunk_batch_samples.size).to be > 0

--- a/spec/integration/container_opened_spec.cr
+++ b/spec/integration/container_opened_spec.cr
@@ -17,7 +17,7 @@ Spectator.describe "Rosegold::Bot container API" do
           admin.tp 30, -60, 30
           admin.setblock 30, -61, 30, "chest"
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
           bot.pitch = 90
           bot.wait_ticks 20
 
@@ -37,7 +37,7 @@ Spectator.describe "Rosegold::Bot container API" do
           admin.tp 30, -60, 30
           admin.setblock 30, -61, 30, "chest{Items:[{Slot:0b, id: \"minecraft:diamond\",count:3b}]}"
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
           bot.pitch = 90
           bot.wait_ticks 20
 
@@ -56,7 +56,7 @@ Spectator.describe "Rosegold::Bot container API" do
         Rosegold::Bot.new(client).try do |bot|
           admin.tp 30, -60, 30
           admin.setblock 30, -61, 30, "chest"
-          bot.wait_ticks 5
+          bot.wait_ticks 2
           bot.pitch = 90
           bot.wait_ticks 20
 

--- a/spec/integration/crafting_spec.cr
+++ b/spec/integration/crafting_spec.cr
@@ -78,9 +78,9 @@ Spectator.describe "Rosegold::Bot crafting" do
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
           admin.clear
-          admin.wait_ticks 5
+          admin.wait_tick
           admin.give "oak_log", 1
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           recipes = bot.recipes_for("oak_planks")
           expect(recipes).to_not be_empty
@@ -94,7 +94,7 @@ Spectator.describe "Rosegold::Bot crafting" do
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
           admin.clear
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           recipes = bot.recipes_for("oak_planks")
           expect(recipes).to_not be_empty
@@ -110,9 +110,9 @@ Spectator.describe "Rosegold::Bot crafting" do
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
           admin.clear
-          admin.wait_ticks 5
+          admin.wait_tick
           admin.give "oak_log", 4
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.craft("oak_planks", 4)
           bot.wait_ticks 10
@@ -127,9 +127,9 @@ Spectator.describe "Rosegold::Bot crafting" do
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
           admin.clear
-          admin.wait_ticks 5
+          admin.wait_tick
           admin.give "oak_planks", 2
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.craft("stick")
           bot.wait_ticks 10
@@ -144,9 +144,9 @@ Spectator.describe "Rosegold::Bot crafting" do
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
           admin.clear
-          admin.wait_ticks 5
+          admin.wait_tick
           admin.give "oak_log", 8
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.craft("oak_planks", 8)
           bot.wait_ticks 10
@@ -158,16 +158,16 @@ Spectator.describe "Rosegold::Bot crafting" do
 
     it "crafts with a crafting table for 3x3 recipes" do
       admin.setblock 2, -59, 0, "crafting_table"
-      admin.wait_ticks 5
+      admin.wait_tick
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
           admin.clear
-          admin.wait_ticks 5
+          admin.wait_tick
           admin.tp 0, -59, 0
-          bot.wait_ticks 10
+          bot.wait_ticks 3
           admin.give "cobblestone", 8
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.craft("furnace", table: Rosegold::Vec3i.new(2, -59, 0))
           bot.wait_ticks 10
@@ -184,9 +184,9 @@ Spectator.describe "Rosegold::Bot crafting" do
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
           admin.clear
-          admin.wait_ticks 5
+          admin.wait_tick
           admin.give "oak_log", 4
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.craft_all("oak_planks")
           bot.wait_ticks 10
@@ -198,16 +198,16 @@ Spectator.describe "Rosegold::Bot crafting" do
 
     it "crafts all hay_blocks from 12 stacks of wheat" do
       admin.setblock 2, -59, 0, "crafting_table"
-      admin.wait_ticks 5
+      admin.wait_tick
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
           admin.clear
-          admin.wait_ticks 5
+          admin.wait_tick
           admin.tp 0, -59, 0
-          bot.wait_ticks 10
+          bot.wait_ticks 3
           admin.give "wheat", 12*64
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.craft_all("hay_block", table: Rosegold::Vec3i.new(2, -59, 0))
           bot.wait_ticks 20
@@ -220,16 +220,16 @@ Spectator.describe "Rosegold::Bot crafting" do
 
     it "crafts hay_blocks from less than a full grid fill" do
       admin.setblock 2, -59, 0, "crafting_table"
-      admin.wait_ticks 5
+      admin.wait_tick
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
           admin.clear
-          admin.wait_ticks 5
+          admin.wait_tick
           admin.tp 0, -59, 0
-          bot.wait_ticks 10
+          bot.wait_ticks 3
           admin.give "wheat", 18
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.craft_all("hay_block", table: Rosegold::Vec3i.new(2, -59, 0))
           bot.wait_ticks 20
@@ -247,7 +247,7 @@ Spectator.describe "Rosegold::Bot crafting" do
         Rosegold::Bot.new(client).try do |bot|
           wait_for_recipes(bot)
           admin.clear
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           expect { bot.craft("diamond_sword") }.to raise_error(Rosegold::Bot::CraftingError)
         end
@@ -270,9 +270,9 @@ Spectator.describe "Rosegold::Bot crafting" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           admin.clear
-          admin.wait_ticks 5
+          admin.wait_tick
           admin.give "oak_log", 1
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.craft_pattern([["oak_log"]])
           bot.wait_ticks 10
@@ -286,9 +286,9 @@ Spectator.describe "Rosegold::Bot crafting" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           admin.clear
-          admin.wait_ticks 5
+          admin.wait_tick
           admin.give "oak_planks", 4
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.craft_pattern([
             ["oak_planks", "oak_planks"],
@@ -305,7 +305,7 @@ Spectator.describe "Rosegold::Bot crafting" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           admin.clear
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           expect { bot.craft_pattern([["diamond", "diamond", "diamond"]]) }.to raise_error(Rosegold::Bot::CraftingError)
         end

--- a/spec/integration/disconnection_spec.cr
+++ b/spec/integration/disconnection_spec.cr
@@ -4,22 +4,12 @@ require "log/spec"
 Spectator.describe "Rosegold::Client disconnection" do
   it "should handle disconnection via kick command" do
     client.join_game do |client|
-      disconnected = false
-      disconnect_reason : Rosegold::TextComponent? = nil
-
-      client.on(Rosegold::Event::Disconnected) do |event|
-        disconnected = true
-        disconnect_reason = event.reason
-      end
-
-      Rosegold::Bot.new(client).try do |bot|
-        bot.wait_ticks 5
+      disconnect_event = client.wait_for(Rosegold::Event::Disconnected, timeout: 5.seconds) do
         admin.chat "/kick #{AdminBot::TEST_PLAYER}"
-        bot.wait_ticks 10
-
-        expect(disconnected).to be_true
-        expect(disconnect_reason).to_not be_nil
       end
+
+      expect(disconnect_event).to_not be_nil
+      expect(disconnect_event.try(&.reason)).to_not be_nil
     end
   end
 
@@ -27,10 +17,8 @@ Spectator.describe "Rosegold::Client disconnection" do
     Log.capture("rosegold") do |logs|
       begin
         client.join_game do |client|
-          Rosegold::Bot.new(client).try do |bot|
-            bot.wait_ticks 5
+          client.wait_for(Rosegold::Event::Disconnected, timeout: 5.seconds) do
             admin.chat "/kick #{AdminBot::TEST_PLAYER}"
-            bot.wait_ticks 10
           end
         end
       rescue Rosegold::Client::NotConnected

--- a/spec/integration/iceroad_spec.cr
+++ b/spec/integration/iceroad_spec.cr
@@ -13,7 +13,7 @@ Spectator.describe "Rosegold::Bot ice road physics" do
     admin.fill 20, base_y + 1, 0, 20, base_y + 1, 40, "stone_button[face=floor]"
     admin.fill 20, base_y + 2, 0, 20, base_y + 2, 40, "oak_trapdoor[half=top]"
     admin.fill 20, base_y + 3, 0, 20, base_y + 3, 40, "obsidian"
-    admin.wait_ticks 5
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.tp start_pos.x, start_pos.y, start_pos.z

--- a/spec/integration/interactions_spec.cr
+++ b/spec/integration/interactions_spec.cr
@@ -4,7 +4,7 @@ Spectator.describe "Rosegold::Bot interactions" do
   before_all do
     admin.kill_entities
     admin.fill -10, -60, -10, 10, 0, 10, "air"
-    admin.wait_ticks 20
+    admin.wait_ticks 3
   end
 
   it "should be able to chat" do
@@ -19,11 +19,10 @@ Spectator.describe "Rosegold::Bot interactions" do
 
   it "should be able to dig continuously through 3 blocks" do
     admin.fill 9, -60, 10, 9, -58, 10, "dirt"
-    admin.wait_ticks 5
+    admin.wait_ticks 3
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.clear
-        admin.wait_ticks 5
         admin.tp 9, -57, 10
         bot.wait_ticks 10
 
@@ -73,7 +72,7 @@ Spectator.describe "Rosegold::Bot interactions" do
 
   it "should stop digging when bot.stop_digging is called" do
     admin.fill 10, -60, 9, 10, -57, 9, "dirt"
-    admin.wait_ticks 5
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.tp 10, -56, 9
@@ -84,7 +83,7 @@ Spectator.describe "Rosegold::Bot interactions" do
         bot.start_digging
         bot.stop_digging
 
-        sleep 1.second # long enough to dig 1 block, if it didn't stop
+        bot.wait_ticks 20 # long enough to dig 1 block, if it didn't stop
 
         expect(bot.location.y).to be >= -56
       end
@@ -96,9 +95,7 @@ Spectator.describe "Rosegold::Bot interactions" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.clear
-        admin.wait_ticks 5
         admin.give "diamond_pickaxe"
-        admin.wait_ticks 10
         admin.tp 8, -59, 8
         bot.wait_ticks 10
 
@@ -143,13 +140,11 @@ Spectator.describe "Rosegold::Bot interactions" do
 
   it "should be able to dig obsidian with diamond pickaxe and efficiency" do
     admin.fill 9, -60, 9, 9, -60, 9, "obsidian"
-    admin.wait_ticks 5
+    admin.wait_ticks 3
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.clear
-        admin.wait_ticks 5
         admin.give "diamond_pickaxe[enchantments={\"minecraft:efficiency\":5}]"
-        admin.wait_ticks 5
         admin.tp 9, -59, 9
         bot.wait_ticks 10
 
@@ -196,15 +191,14 @@ Spectator.describe "Rosegold::Bot interactions" do
 
   it "should be able to place blocks" do
     admin.kill_entities
-    admin.wait_ticks 5
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.tp 10, -60, 10
         bot.wait_ticks 10
         admin.clear
-        admin.wait_ticks 10
         admin.give "obsidian", 64
-        bot.wait_ticks 10
+        bot.wait_ticks 3
 
         bot.inventory.pick! "obsidian"
         bot.wait_ticks 5
@@ -231,7 +225,7 @@ Spectator.describe "Rosegold::Bot interactions" do
         # Mimic vine farm: stone above, vine hangs below with inherited face
         admin.setblock 5, -59, 6, "stone"
         admin.setblock 5, -60, 6, "vine[west=true]"
-        admin.wait_ticks 10
+        admin.wait_ticks 5
 
         vine_state = client.dimension_for_test.block_state(5, -60, 6)
         vine_name = Rosegold::MCData.default.block_state_names[vine_state.as(UInt16)]
@@ -244,7 +238,7 @@ Spectator.describe "Rosegold::Bot interactions" do
         admin.tp 3.5, -60, 6.5
         admin.clear
         admin.give "shears"
-        admin.wait_ticks 10
+        bot.wait_ticks 10
 
         bot.inventory.pick! "shears"
         bot.wait_ticks 5
@@ -281,7 +275,7 @@ Spectator.describe "Rosegold::Bot interactions" do
         admin.tp 6.5, -60, 7.5
         admin.clear
         admin.give "bone_meal", 10
-        bot.wait_ticks 5
+        bot.wait_ticks 10
 
         # Verify wheat was created at age 0
         wheat_age_0 = client.dimension_for_test.block_state(6, -59, 6)

--- a/spec/integration/inventory_spec.cr
+++ b/spec/integration/inventory_spec.cr
@@ -7,7 +7,7 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             expect(bot.inventory.count("bucket")).to eq 0
           end
@@ -20,12 +20,12 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             admin.give "bucket", 16
             admin.give "bucket", 1
             admin.give "bucket", 5
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             expect(bot.inventory.count("bucket")).to eq 16 + 1 + 5
           end
@@ -38,10 +38,10 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             admin.give "bucket", 513
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             expect(bot.inventory.count("bucket")).to eq 513
           end
@@ -56,7 +56,7 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             expect(bot.inventory.pick("diamond_pickaxe")).to eq false
             expect(bot.inventory.pick("stone")).to eq false
@@ -71,11 +71,11 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.give "stone", 42
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.give "grass_block", 43
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             expect(bot.inventory.pick("stone")).to eq true
             expect(bot.inventory.main_hand.name).to eq "stone"
@@ -91,11 +91,11 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.give "stone", 64*9
-            bot.wait_ticks 10
+            bot.wait_ticks 3
             admin.give "grass_block"
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             expect(bot.inventory.pick("grass_block")).to eq true
             expect(bot.inventory.main_hand.name).to eq "grass_block"
@@ -109,13 +109,13 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             # Give undamaged diamond pickaxe first (will go to hotbar slot 0)
             admin.give "diamond_pickaxe"
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             # Give damaged diamond pickaxe (will go to hotbar slot 1)
             admin.give "diamond_pickaxe[damage=1400]"
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Switch away from the pickaxes first
             bot.hotbar_selection = 3_u8
@@ -140,7 +140,7 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             expect { bot.inventory.pick!("diamond_pickaxe") }.to raise_error(Rosegold::Inventory::ItemNotFoundError)
           end
         end
@@ -152,9 +152,9 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.give "diamond_pickaxe[damage=1550,enchantments={\"minecraft:efficiency\":1}]"
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             expect { bot.inventory.pick!("diamond_pickaxe") }.to raise_error(Rosegold::Inventory::ItemNotFoundError)
           end
         end
@@ -171,7 +171,7 @@ Spectator.describe "Rosegold::Bot inventory" do
           bot.wait_tick
           admin.setblock 30, -61, 30, "chest{Items:[{Slot:7b, id: \"minecraft:diamond_sword\",count:1b},{Slot:6b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":100}}]}"
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
           bot.pitch = 90
           bot.wait_ticks 20
 
@@ -216,7 +216,7 @@ Spectator.describe "Rosegold::Bot inventory" do
           # Create chest with two diamond pickaxes: one undamaged, one heavily damaged
           admin.setblock 30, -61, 30, "chest{Items:[{Slot:0b, id: \"minecraft:diamond_pickaxe\",count:1b},{Slot:1b, id: \"minecraft:diamond_pickaxe\",count:1b,components:{\"minecraft:damage\":1400}}]}"
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
           bot.wait_tick
 
           bot.pitch = 90
@@ -255,7 +255,7 @@ Spectator.describe "Rosegold::Bot inventory" do
           # Create chest with multiple diamond swords of varying durability
           admin.setblock 30, -61, 30, "chest{Items:[{Slot:0b, id: \"minecraft:diamond_sword\",count:1b},{Slot:1b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":800}},{Slot:2b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":1200}},{Slot:3b, id: \"minecraft:diamond_sword\",count:1b,components:{\"minecraft:damage\":400}}]}"
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
           bot.wait_tick
 
           bot.pitch = 90
@@ -297,7 +297,7 @@ Spectator.describe "Rosegold::Bot inventory" do
           admin.setblock 30, -61, 30, "chest{Items:[#{items_array.join(",")}]}", "replace"
           bot.wait_tick
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
 
           # Open the chest
           bot.pitch = 90
@@ -339,11 +339,11 @@ Spectator.describe "Rosegold::Bot inventory" do
           admin.setblock 30, -61, 30, "chest{Items:[]}", "replace"
           bot.wait_tick
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
 
           # Give player exactly 20 stacks of cobblestone (1280 items)
           admin.give "cobblestone", 1280
-          bot.wait_ticks 5
+          bot.wait_ticks 2
 
           # Open the chest
           bot.pitch = 90
@@ -408,9 +408,9 @@ Spectator.describe "Rosegold::Bot inventory" do
           bot.wait_tick
           admin.setblock 30, -61, 30, "chest{Items:[]}"
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
           admin.give "diamond_sword"
-          bot.wait_ticks 5
+          bot.wait_ticks 2
 
           bot.pitch = 90
           bot.use_hand
@@ -481,11 +481,11 @@ Spectator.describe "Rosegold::Bot inventory" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
           admin.give "diamond_sword", 4
-          bot.wait_ticks 5
+          bot.wait_ticks 2
           admin.give "stone", 200
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.look = Rosegold::Look.new 0, 0
           expect(bot.inventory.throw_all_of "diamond_sword").to eq 4
@@ -506,9 +506,9 @@ Spectator.describe "Rosegold::Bot inventory" do
       client.join_game do |client|
         Rosegold::Bot.new(client).try do |bot|
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
           admin.give "lava_bucket", 33
-          bot.wait_ticks 10
+          bot.wait_ticks 3
 
           bot.look = Rosegold::Look.new 0, 0
           expect(bot.inventory.throw_all_of "lava_bucket").to eq 33
@@ -542,7 +542,7 @@ Spectator.describe "Rosegold::Bot inventory" do
           bot.wait_tick
 
           admin.clear
-          bot.wait_ticks 5
+          bot.wait_ticks 2
 
           # Open the chest
           bot.pitch = 90
@@ -586,11 +586,11 @@ Spectator.describe "Rosegold::Bot inventory" do
             admin.setblock 30, -61, 30, "chest{Items:[#{items_array}]}", "replace"
             bot.wait_tick
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Give player diamond swords to try to deposit into the full chest
             admin.give "diamond_sword", 3
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Open the chest
             bot.pitch = 90
@@ -642,13 +642,13 @@ Spectator.describe "Rosegold::Bot inventory" do
             admin.setblock 30, -61, 30, "chest{Items:[#{items_array.join(",")}]}", "replace"
             bot.wait_tick
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Give player diamond swords and cobblestone to deposit
             admin.give "diamond_sword", 10
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.give "cobblestone", 64
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Open the chest
             bot.pitch = 90
@@ -710,9 +710,9 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.give "stone", 15
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             result = bot.inventory.replenish 10, "stone"
             expect(result).to eq 15
@@ -733,9 +733,9 @@ Spectator.describe "Rosegold::Bot inventory" do
             admin.clear
             admin.wait_tick
             admin.give "stone", 2
-            admin.wait_ticks 5
+            admin.wait_tick
             bot.pitch = 90
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             bot.use_hand
             bot.wait_for Rosegold::Clientbound::SetContainerContent
 
@@ -756,7 +756,7 @@ Spectator.describe "Rosegold::Bot inventory" do
             admin.wait_tick
             admin.chat "/execute at #{AdminBot::TEST_PLAYER} run setblock ~ ~ ~ minecraft:chest{Items:[{Slot:0b, id: \"minecraft:diamond\",count:5b}]}"
             admin.clear
-            admin.wait_ticks 5
+            admin.wait_tick
 
             bot.pitch = 90
             bot.use_hand
@@ -778,9 +778,9 @@ Spectator.describe "Rosegold::Bot inventory" do
             admin.wait_tick
             admin.chat "/execute at #{AdminBot::TEST_PLAYER} run setblock ~ ~ ~ minecraft:chest{Items:[{Slot:0b, id: \"minecraft:gold_ingot\",count:2b}]}"
             admin.clear
-            admin.wait_ticks 5
+            admin.wait_tick
             admin.give "gold_ingot"
-            admin.wait_ticks 5
+            admin.wait_tick
 
             bot.pitch = 90
             bot.use_hand
@@ -803,7 +803,7 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Give one full set of diamond armor and shield
             admin.give "diamond_helmet"
@@ -811,7 +811,7 @@ Spectator.describe "Rosegold::Bot inventory" do
             admin.give "diamond_leggings"
             admin.give "diamond_boots"
             admin.give "shield"
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Find equipment items in inventory
             helmet_slot = (bot.inventory.inventory + bot.inventory.hotbar).find { |slot| slot.name == "diamond_helmet" }
@@ -861,7 +861,7 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             expect(bot.inventory.refill_hand).to eq 0
           end
@@ -874,14 +874,14 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Set up: 16 stone in main hand, 32 stone in main inventory
             bot.hotbar_selection = 1_u8
             admin.item_replace "hotbar.0", "stone", 16
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.item_replace "inventory.0", "stone", 32
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Test refill functionality - document current behavior
             initial_count = bot.inventory.main_hand.count
@@ -913,14 +913,14 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Set up: 10 diamond in main hand, 20 diamond in another hotbar slot, NO diamond in main inventory
             bot.hotbar_selection = 1_u8
             admin.item_replace "hotbar.0", "diamond", 10
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.item_replace "hotbar.1", "diamond", 20
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Test refill_hand functionality - should combine 10 + 20 = 30 total
             initial_count = bot.inventory.main_hand.count
@@ -951,17 +951,17 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Set up: 32 stone in main hand, 64 stone in inventory, 32 stone in hotbar
             # Total: 128 stone, but max stack is 64
             bot.hotbar_selection = 1_u8
             admin.item_replace "hotbar.0", "stone", 32
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.item_replace "inventory.0", "stone", 64
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.item_replace "hotbar.1", "stone", 32
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Test that refill stops at max stack size (64)
             initial_count = bot.inventory.main_hand.count
@@ -981,11 +981,11 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Give exactly 64 stone (max stack)
             admin.give "stone", 64
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Should return 64 without doing anything
             expect(bot.inventory.main_hand.count).to eq 64
@@ -1000,13 +1000,13 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Give 32 stone in hand and dirt in inventory (no matching items)
             admin.give "stone", 32
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.give "dirt", 64
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Should return current count since no more stone available
             expect(bot.inventory.main_hand.count).to eq 32
@@ -1023,7 +1023,7 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Teleport to known location and create chest
             admin.tp 30.5, -60, 30.5
@@ -1033,9 +1033,9 @@ Spectator.describe "Rosegold::Bot inventory" do
 
             # Give stone - first to main hand, second to inventory
             admin.give "stone", 32
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.give "stone", 32
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             main_hand_count_before_container = bot.inventory.main_hand.count
 
@@ -1067,13 +1067,13 @@ Spectator.describe "Rosegold::Bot inventory" do
         client.join_game do |client|
           Rosegold::Bot.new(client).try do |bot|
             admin.clear
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Give sword (non-stackable item)
             admin.give "diamond_sword"
-            bot.wait_ticks 5
+            bot.wait_ticks 2
             admin.give "diamond_sword"
-            bot.wait_ticks 5
+            bot.wait_ticks 2
 
             # Should return 1 since swords don't stack
             expect(bot.inventory.main_hand.count).to eq 1

--- a/spec/integration/movement_spec.cr
+++ b/spec/integration/movement_spec.cr
@@ -77,7 +77,7 @@ Spectator.describe "Rosegold::Bot movement" do
         initial_feet = bot.location
 
         bot.start_jump
-        sleep 0.5.seconds # allow time for the jump
+        bot.wait_ticks 10
 
         expect(bot.location.y).to be > initial_feet.y
 

--- a/spec/integration/movement_speed_spec.cr
+++ b/spec/integration/movement_speed_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 Spectator.describe "Rosegold::Bot movement speeds" do
   before_all do
     admin.setup_arena
-    admin.wait_ticks 19
+    admin.wait_tick
   end
 
   it "should have correct movement speeds for sneak, walk, and sprint" do
@@ -11,7 +11,7 @@ Spectator.describe "Rosegold::Bot movement speeds" do
       Rosegold::Bot.new(client).try do |bot|
         bot.wait_ticks 5
         admin.tp 0, -60, 0
-        bot.wait_ticks 10
+        bot.wait_ticks 3
 
         bot.sneak(true)
         bot.wait_ticks 2
@@ -21,7 +21,7 @@ Spectator.describe "Rosegold::Bot movement speeds" do
         sneak_speed = 5.0 / sneak_time.total_seconds
 
         admin.tp 0, -60, 0
-        bot.wait_ticks 10
+        bot.wait_ticks 3
         bot.sneak(false)
         bot.wait_ticks 2
 
@@ -31,7 +31,7 @@ Spectator.describe "Rosegold::Bot movement speeds" do
         walk_speed = 5.0 / walk_time.total_seconds
 
         admin.tp 0, -60, 0
-        bot.wait_ticks 10
+        bot.wait_ticks 3
 
         bot.sprint(true)
         bot.wait_ticks 2

--- a/spec/integration/sneak_edge_spec.cr
+++ b/spec/integration/sneak_edge_spec.cr
@@ -8,11 +8,11 @@ Spectator.describe "Rosegold::Bot sneak edge prevention" do
   it "should not fall off edge when sneaking" do
     admin.fill -2, -60, -2, 4, -56, 4, "air"
     admin.setblock 0, -57, 0, "stone"
-    admin.wait_ticks 5
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.tp 0, -56, 0
-        bot.wait_ticks 5
+        bot.wait_ticks 2
         until client.player.on_ground?
           bot.wait_tick
         end
@@ -38,11 +38,11 @@ Spectator.describe "Rosegold::Bot sneak edge prevention" do
   it "should fall off edge when not sneaking" do
     admin.fill -2, -60, -2, 4, -56, 4, "air"
     admin.setblock 0, -57, 0, "stone"
-    admin.wait_ticks 5
+    admin.wait_tick
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|
         admin.tp 0, -56, 0
-        bot.wait_ticks 5
+        bot.wait_ticks 2
         until client.player.on_ground?
           bot.wait_tick
         end

--- a/spec/integration/spectate_server_spec.cr
+++ b/spec/integration/spectate_server_spec.cr
@@ -31,8 +31,11 @@ Spectator.describe "SpectateServer Integration" do
       begin
         spectator.connect
 
-        # Give enough time for all packets to arrive
-        sleep 2.seconds
+        # Wait until basic play state has arrived
+        deadline = Time.instant + 5.seconds
+        until (spectator.player.entity_id != 0_u64 && spectator.dimension_for_test.chunks.size > 0) || Time.instant > deadline
+          sleep 10.milliseconds
+        end
 
         unless spectator.connected?
           fail("Spectator disconnected: #{spectator.connection?.try(&.close_reason)}")

--- a/src/rosegold/models/event_emitter.cr
+++ b/src/rosegold/models/event_emitter.cr
@@ -45,7 +45,7 @@ class Rosegold::EventEmitter
 
     until ran_event
       return nil if (Time.utc - time_start) > timeout
-      sleep 0.01.seconds
+      sleep 1.milliseconds
     end
 
     ran_event
@@ -64,7 +64,7 @@ class Rosegold::EventEmitter
 
     until ran_event
       raise "Timed out waiting for #{event_type} after #{timeout}" if (Time.utc - time_start) > timeout
-      sleep 0.01.seconds
+      sleep 1.milliseconds
     end
 
     ran_event.as(T)


### PR DESCRIPTION
## Summary

Brings the full `crystal spec` run down from **~3:40 to ~2:13** (~40% faster, ~87s saved) with no regressions. Verified across eight consecutive clean runs (times 2:12 – 2:18, 0 failures each).

The suite was spending most of its time in `wait_ticks` padding sized for worst-case latency rather than the observed localhost RTT (<5ms). This PR trims those waits where they were gratuitous and replaces a handful of literal `sleep` calls with event/tick-based waits — while preserving every spec that was load-bearing.

### Before

```
Finished in 3:40
497 examples, 0 failures
Top 10 slowest: 1:09 (31% of total)
  disconnection kick          10.17s  ← wait_ticks hit 1s timeout per tick after kick
  disconnection log            9.7s   ← same
  movement speeds              9.3s
  chat handle lengths          6.83s  ← three vacuous expect(true) variants
  attack through blocks        6.51s
  ...
```

### After

```
Finished in 2:13
493 examples, 0 failures      ← 4 fewer: chat_spec variants consolidated into one
Top 10 slowest: ~49s (~31% of total)
  movement speeds              7.68s
  dig continuous 3 blocks      5.47s
  ice road                     5.33s
  button on ground             4.6s
  attack even if moving        4.33s
  ...
```

### What changed

- **Dead waits trimmed**: `bot.wait_ticks 10 → 3`, `bot.wait_ticks 5 → 2` after admin state changes (`/clear`, `/give`, `/tp`, `/setblock`, `/fill`); `admin.wait_ticks N → admin.wait_tick` or removed when followed by a bot wait.
- **Sleeps → event waits**:
  - `chunk_batch_spec` now uses block-form `client.wait_for(Clientbound::ChunkBatchFinished)` so the test returns as soon as the batch completes, not at a fixed 2s.
  - `spectate_server_spec` polls spectator state against a 5s deadline instead of a flat 2s sleep.
  - `movement_spec`'s `sleep 0.5s` and `interactions_spec`'s `sleep 1.second` are now tick waits that bail early on disconnect.
- **EventEmitter poll**: `wait_for`'s internal sleep dropped from 10ms to 1ms so synchronous packet waits resolve quickly.
- **Disconnection specs (from a prior commit on this branch)**: switched to `wait_for(Event::Disconnected)` so the tests don't burn 10s each on post-kick wait_ticks hitting the 1s timeout per tick. This alone saved ~20s.
- **Chat specs (same prior commit)**: collapsed six variants that only asserted `expect(true).to be_true` into two meaningful tests (DisguisedChatMessage + SystemChatMessage receipt).

### Preserved deliberately

- Bounded polling loops (`until cond || ticks_waited >= timeout`) for block break progress, mine timing, entity spawn observation.
- Button test's `bot.wait_ticks 30` (stone button 20-tick press duration).
- `interactions_spec`'s 20-tick wait that verifies `stop_digging` actually stopped.
- Chunk-load waits (`bot.wait_ticks 15`) after long teleports in `button_spec`.
- Crafting `bot.wait_ticks 20` after `craft_all` for hay_block (12 stacks of wheat → 85 hay_blocks takes real time).

### Test plan

- [x] `crystal spec` — 8 consecutive runs, 0 failures, 2:12 – 2:18
- [x] `crystal tool format --check`
- [x] `./bin/ameba` — clean
- [x] `crystal build --no-codegen src/rosegold.cr` — type-checks clean
- [ ] CI matrix (1.21.8, 1.21.11, 26.1) — will be validated by the GitHub Actions run on this PR