### PR TITLE
Forward chat and tab-complete from spectators

### DIFF
--- a/src/rosegold/packets/clientbound/command_suggestions_response.cr
+++ b/src/rosegold/packets/clientbound/command_suggestions_response.cr
@@ -1,0 +1,54 @@
+require "../../models/text_component"
+require "../packet"
+
+class Rosegold::Clientbound::CommandSuggestionsResponse < Rosegold::Clientbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+
+  packet_ids({
+    772_u32 => 0x0F_u32,
+    774_u32 => 0x0F_u32,
+    775_u32 => 0x0F_u32,
+  })
+
+  record Match, text : String, tooltip : Rosegold::TextComponent? = nil
+
+  property transaction_id : UInt32
+  property start : UInt32
+  property length : UInt32
+  property matches : Array(Match)
+
+  def initialize(@transaction_id, @start, @length, @matches); end
+
+  def self.read(io)
+    transaction_id = io.read_var_int
+    start = io.read_var_int
+    length = io.read_var_int
+    count = io.read_var_int
+    matches = Array(Match).new(count)
+    count.times do
+      text = io.read_var_string
+      tooltip = io.read_bool ? io.read_text_component : nil
+      matches << Match.new(text, tooltip)
+    end
+    self.new(transaction_id, start, length, matches)
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      buffer.write transaction_id
+      buffer.write start
+      buffer.write length
+      buffer.write matches.size.to_u32
+      matches.each do |match|
+        buffer.write match.text
+        if tooltip = match.tooltip
+          buffer.write true
+          tooltip.write(buffer)
+        else
+          buffer.write false
+        end
+      end
+    end.to_slice
+  end
+end

--- a/src/rosegold/packets/serverbound/command_suggestions_request.cr
+++ b/src/rosegold/packets/serverbound/command_suggestions_request.cr
@@ -1,0 +1,30 @@
+require "../packet"
+
+class Rosegold::Serverbound::CommandSuggestionsRequest < Rosegold::Serverbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+
+  packet_ids({
+    772_u32 => 0x0E_u32,
+    774_u32 => 0x0E_u32,
+    775_u32 => 0x0E_u32,
+  })
+
+  property transaction_id : UInt32
+  property text : String
+
+  def initialize(@transaction_id : UInt32, @text : String); end
+
+  def self.read(io)
+    transaction_id = io.read_var_int
+    text = io.read_var_string
+    self.new(transaction_id, text)
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      buffer.write transaction_id
+      buffer.write text
+    end.to_slice
+  end
+end

--- a/src/rosegold/spectate/connection.cr
+++ b/src/rosegold/spectate/connection.cr
@@ -40,11 +40,11 @@ class Rosegold::Spectate::Connection
   @packet_send_mutex = Mutex.new
   @transition_mutex = Mutex.new
 
-  # Event handler IDs for cleanup
-  @raw_packet_handler_id : UUID? = nil
-  @position_handler_id : UUID? = nil
-  @arm_swing_handler_id : UUID? = nil
-  @container_closed_handler_id : UUID? = nil
+  @bot_handler_cleanups : Array(->) = [] of ->
+
+  COMMAND_SUGGESTION_MAP_LIMIT = 256
+  @command_suggestion_map : Hash(UInt32, UInt32) = {} of UInt32 => UInt32
+  @command_suggestion_map_mutex = Mutex.new
 
   def initialize(raw_socket : TCPSocket, @spectate_server : Server)
     @socket = Minecraft::IO::Wrap.new(raw_socket)
@@ -98,6 +98,12 @@ class Rosegold::Spectate::Connection
         handle_keep_alive(packet)
       when Rosegold::Serverbound::TeleportConfirm
         Log.trace { "Received teleport confirm: #{packet.teleport_id}" }
+      when Rosegold::Serverbound::ChatMessage
+        handle_chat_message(packet)
+      when Rosegold::Serverbound::ChatCommand
+        handle_chat_command(packet)
+      when Rosegold::Serverbound::CommandSuggestionsRequest
+        handle_command_suggestions_request(packet)
       else
         Log.trace { "Unhandled packet: #{packet.class.name}" }
       end
@@ -148,19 +154,59 @@ class Rosegold::Spectate::Connection
     # Socket already closed
   end
 
-  private def cleanup_event_handlers
+  protected def track_bot_handler(event_type : T.class, &block : T ->) forall T
     bot = @client
     return unless bot
+    id = bot.on(event_type, &block)
+    @bot_handler_cleanups << -> { bot.off(event_type, id) }
+  end
 
-    @raw_packet_handler_id.try { |id| bot.off(Event::RawPacket, id) }
-    @position_handler_id.try { |id| bot.off(Event::PlayerPositionUpdate, id) }
-    @arm_swing_handler_id.try { |id| bot.off(Event::ArmSwing, id) }
-    @container_closed_handler_id.try { |id| bot.off(Event::ContainerClosed, id) }
+  private def cleanup_event_handlers
+    @bot_handler_cleanups.each(&.call)
+    @bot_handler_cleanups.clear
+    @command_suggestion_map_mutex.synchronize { @command_suggestion_map.clear }
+  end
 
-    @raw_packet_handler_id = nil
-    @position_handler_id = nil
-    @arm_swing_handler_id = nil
-    @container_closed_handler_id = nil
+  private def handle_chat_message(packet : Rosegold::Serverbound::ChatMessage)
+    return unless @spectate_state.spectating?
+    bot = @client
+    return unless bot && bot.connected?
+
+    Log.debug { "Forwarding spectator chat: #{packet.message}" }
+    bot.chat_manager.send_message(packet.message)
+  rescue ex
+    Log.error { "Failed to forward spectator chat: #{ex}" }
+  end
+
+  private def handle_chat_command(packet : Rosegold::Serverbound::ChatCommand)
+    return unless @spectate_state.spectating?
+    bot = @client
+    return unless bot && bot.connected?
+
+    Log.debug { "Forwarding spectator command: #{packet.command}" }
+    bot.chat_manager.send_command(packet.command)
+  rescue ex
+    Log.error { "Failed to forward spectator command: #{ex}" }
+  end
+
+  private def handle_command_suggestions_request(packet : Rosegold::Serverbound::CommandSuggestionsRequest)
+    return unless @spectate_state.spectating?
+    bot = @client
+    return unless bot && bot.connected?
+
+    bot_tid = @spectate_server.next_command_suggestion_tid
+    @command_suggestion_map_mutex.synchronize do
+      # Bound map growth: a server that drops suggestion requests would otherwise leak entries indefinitely.
+      if @command_suggestion_map.size >= COMMAND_SUGGESTION_MAP_LIMIT
+        @command_suggestion_map.delete(@command_suggestion_map.first_key)
+      end
+      @command_suggestion_map[bot_tid] = packet.transaction_id
+    end
+
+    Log.debug { "Forwarding spectator command suggestions request: tid=#{packet.transaction_id} -> bot_tid=#{bot_tid} text=#{packet.text}" }
+    bot.send_packet!(Rosegold::Serverbound::CommandSuggestionsRequest.new(bot_tid, packet.text))
+  rescue ex
+    Log.error { "Failed to forward spectator command suggestions request: #{ex}" }
   end
 
   def client_ready?

--- a/src/rosegold/spectate/packet_relay.cr
+++ b/src/rosegold/spectate/packet_relay.cr
@@ -30,7 +30,7 @@ module Rosegold::Spectate::PacketRelay
     self_targeted = self_targeted_packet_ids(protocol_version)
     bot_entity_id = bot.player.entity_id
 
-    @raw_packet_handler_id = bot.on(Rosegold::Event::RawPacket) do |event|
+    track_bot_handler(Rosegold::Event::RawPacket) do |event|
       raw_bytes = event.bytes
       next unless raw_bytes.size > 0
       next unless @connected
@@ -40,7 +40,6 @@ module Rosegold::Spectate::PacketRelay
       next unless pkt_id
 
       if _packet_name = forwarded[pkt_id]?
-        # Check if this is a self-targeted packet that needs entity ID remapping
         remapped = if self_targeted.includes?(pkt_id)
                      try_remap_entity_id(raw_bytes, pkt_id, bot_entity_id)
                    end
@@ -59,9 +58,7 @@ module Rosegold::Spectate::PacketRelay
   end
 
   private def setup_position_event_listener
-    return unless bot = @client
-
-    @position_handler_id = bot.on(Rosegold::Event::PlayerPositionUpdate) do |event|
+    track_bot_handler(Rosegold::Event::PlayerPositionUpdate) do |event|
       next unless @connected
       next unless @spectate_state.spectating?
 
@@ -76,9 +73,7 @@ module Rosegold::Spectate::PacketRelay
   end
 
   private def setup_arm_swing_listener
-    return unless bot = @client
-
-    @arm_swing_handler_id = bot.on(Rosegold::Event::ArmSwing) do |event|
+    track_bot_handler(Rosegold::Event::ArmSwing) do |event|
       next unless @connected
       next unless @spectate_state.spectating?
       animation = event.hand.off_hand? ? Rosegold::Clientbound::EntityAnimation::Animation::SwingOffHand : Rosegold::Clientbound::EntityAnimation::Animation::SwingMainArm
@@ -88,9 +83,7 @@ module Rosegold::Spectate::PacketRelay
   end
 
   private def setup_container_closed_listener
-    return unless bot = @client
-
-    @container_closed_handler_id = bot.on(Rosegold::Event::ContainerClosed) do |event|
+    track_bot_handler(Rosegold::Event::ContainerClosed) do |event|
       next unless @connected
       next unless @spectate_state.spectating?
       packet = Rosegold::Clientbound::CloseWindow.new(event.window_id)

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -20,8 +20,37 @@ module Rosegold::Spectate::PlaySession
     setup_position_event_listener
     setup_arm_swing_listener
     setup_container_closed_listener
+    setup_command_suggestions_listener
     setup_raw_packet_relay
+    send_cached_commands
     start_keep_alive_sender
+  end
+
+  private def send_cached_commands
+    bytes = @spectate_server.cached_commands_bytes
+    return unless bytes
+    Log.debug { "Replaying cached Commands packet (#{bytes.size} bytes) to spectator" }
+    send_packet(Rosegold::Clientbound::RawPacket.new(bytes))
+  end
+
+  private def setup_command_suggestions_listener
+    track_bot_handler(Rosegold::Clientbound::CommandSuggestionsResponse) do |event|
+      next unless @connected
+      next unless @spectate_state.spectating?
+
+      spec_tid = @command_suggestion_map_mutex.synchronize do
+        @command_suggestion_map.delete(event.transaction_id)
+      end
+      next unless spec_tid
+
+      response = Rosegold::Clientbound::CommandSuggestionsResponse.new(
+        spec_tid,
+        event.start,
+        event.length,
+        event.matches
+      )
+      send_packet(response)
+    end
   end
 
   private def send_join_game(bot : Rosegold::Client)

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -55,6 +55,7 @@ class Rosegold::Spectate::Server
     "collect"                      => {772_u32 => 0x75_u32, 774_u32 => 0x7A_u32, 775_u32 => 0x7C_u32},
     "attach_entity"                => {772_u32 => 0x5D_u32, 774_u32 => 0x62_u32, 775_u32 => 0x64_u32},
     "entity_teleport"              => {772_u32 => 0x76_u32, 774_u32 => 0x7B_u32, 775_u32 => 0x7D_u32},
+    "commands"                     => {772_u32 => 0x10_u32, 774_u32 => 0x10_u32, 775_u32 => 0x10_u32},
   }
 
   macro build_forwarded_packets_method
@@ -111,7 +112,16 @@ class Rosegold::Spectate::Server
   property server : TCPServer?
   property connections = Array(Connection).new
 
+  getter cached_commands_bytes : Bytes? = nil
+  @bot_commands_handler_id : UUID? = nil
+
+  @next_command_suggestion_tid = Atomic(UInt32).new(0_u32)
+
   def initialize(@host : String = "127.0.0.1", @port : Int32 = 25566)
+  end
+
+  def next_command_suggestion_tid : UInt32
+    @next_command_suggestion_tid.add(1_u32) &+ 1_u32
   end
 
   def start
@@ -157,10 +167,34 @@ class Rosegold::Spectate::Server
   end
 
   def attach_client(client : Rosegold::Client)
+    stop_caching_commands
+    @cached_commands_bytes = nil
     @client = client
+    start_caching_commands(client)
   end
 
   def detach_client
+    stop_caching_commands
+    @cached_commands_bytes = nil
     @client = nil
+  end
+
+  private def start_caching_commands(client : Rosegold::Client)
+    commands_pkt_id = UNIMPLEMENTED_FORWARDED["commands"][client.protocol_version]?
+    return unless commands_pkt_id
+    commands_id_byte = commands_pkt_id.to_u8
+
+    @bot_commands_handler_id = client.on(Rosegold::Event::RawPacket) do |event|
+      next unless event.bytes[0]? == commands_id_byte
+      @cached_commands_bytes = event.bytes
+      Log.debug { "Cached Commands packet (#{event.bytes.size} bytes)" }
+    end
+  end
+
+  private def stop_caching_commands
+    if (client = @client) && (id = @bot_commands_handler_id)
+      client.off(Rosegold::Event::RawPacket, id)
+    end
+    @bot_commands_handler_id = nil
   end
 end


### PR DESCRIPTION
## Summary
- Spectators connected to the SpectateServer can now chat, run commands, and tab-complete against the upstream server via the bot.
- Cache the bot's Commands graph and replay to each spectator on session start so late-joining spectators see the full command tree.
- Per-spectator command-suggestion transaction IDs are remapped onto a server-wide atomic counter; the mapping is bounded to 256 entries.
- Refactor the four `setup_*_listener` methods on `Connection` to share a `track_bot_handler` helper, centralizing handler cleanup.

## Test plan
- [x] Connect a vanilla client to the spectate server, confirm typed chat reaches the upstream server
- [x] Run a `/command` from the spectator and confirm the upstream server processes it
- [x] Tab-complete a known command (e.g. `/g `) and confirm suggestions appear
- [x] Confirm late-joining spectators see commands populated (no "Unknown or incomplete command" for valid commands)
- [x] Disconnect bot mid-session and verify spectator handler/cache cleanup