### PR TITLE
Reclaim spectator slots from dead peers

### DIFF
--- a/spec/packets/serverbound/player_position_and_look_serialization_spec.cr
+++ b/spec/packets/serverbound/player_position_and_look_serialization_spec.cr
@@ -108,6 +108,5 @@ Spectator.describe "PlayerPositionAndLook Serialization" do
     expect(packet_with_extremes.feet.z).to eq(30_000_000.0)          # Clamped to max
     expect(packet_with_extremes.look.yaw).to be_close(0.0, 0.001)    # 720 - 360 - 360 = 0
     expect(packet_with_extremes.look.pitch).to be_close(90.0, 0.001) # -270 + 360 = 90
-
   end
 end

--- a/src/rosegold/spectate/connection.cr
+++ b/src/rosegold/spectate/connection.cr
@@ -140,9 +140,11 @@ class Rosegold::Spectate::Connection
       socket.flush
     end
   rescue ex : IO::Error
-    Log.debug { "Failed to send packet: #{ex}" }
+    Log.debug { "Failed to send packet, closing connection: #{ex}" }
+    close
   rescue ex
     Log.error { "Packet send error: #{ex}" }
+    close
   end
 
   def close

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -133,11 +133,15 @@ class Rosegold::Spectate::Server
         begin
           client_socket = server.accept
 
+          @connections.reject! { |conn| !conn.connected? }
+
           if @connections.size >= MAX_CONNECTIONS
             Log.warn { "Max connections reached, rejecting #{client_socket.remote_address}" }
             client_socket.close
             next
           end
+
+          enable_tcp_keepalive(client_socket)
 
           Log.info { "New spectator connection from #{client_socket.remote_address}" }
 
@@ -164,6 +168,15 @@ class Rosegold::Spectate::Server
     @server.try &.close
     @connections.dup.each(&.close)
     @connections.clear
+  end
+
+  private def enable_tcp_keepalive(socket : TCPSocket)
+    socket.keepalive = true
+    socket.tcp_keepalive_idle = 30
+    socket.tcp_keepalive_interval = 10
+    socket.tcp_keepalive_count = 3
+  rescue ex
+    Log.debug { "Failed to enable TCP keepalive: #{ex}" }
   end
 
   def attach_client(client : Rosegold::Client)


### PR DESCRIPTION
## Summary
- `Connection#send_packet` no longer swallows `IO::Error` silently — it calls `close`, which flips `@connected`, closes the socket, and unblocks `read_raw_packet` so the spawn's `ensure` block removes the entry from `@connections`.
- Defensive purge of any already-disconnected entries before the `MAX_CONNECTIONS` check.
- Enable kernel TCP keep-alive on accepted sockets (30s idle / 10s interval / 3 probes ≈ 60s) so dead peers are detected without depending on application-level traffic.

## Why
Long-running sessions eventually hit `WARN - Max connections reached, rejecting <addr>`. The 10-slot cap filled because spectators whose networks died ungracefully (NAT timeout, wifi drop, RST never delivered) left behind connection slots: the keep-alive loop's `send_packet` failed every 20s and was logged at debug, but the connection was never torn down, so `read_raw_packet` stayed blocked forever and `@connections.delete` never ran.

## Test plan
- [ ] Verify with a long-running session that disconnected spectators free their slot within ~60s (TCP keep-alive timeout) rather than hours
- [ ] Verify normal spectator connect/disconnect still works
- [ ] Confirm `crystal build --no-codegen src/rosegold.cr` passes (done locally)