### PR TITLE
Replay scoreboard state to new spectators

### DIFF
--- a/spec/rosegold/spectate/scoreboard_cache_spec.cr
+++ b/spec/rosegold/spectate/scoreboard_cache_spec.cr
@@ -1,0 +1,229 @@
+require "../../spec_helper"
+
+private def build_packet(packet_id : UInt32, & : Minecraft::IO::Memory -> _) : Bytes
+  io = Minecraft::IO::Memory.new
+  io.write packet_id
+  yield io
+  io.to_slice.dup
+end
+
+private def write_objective(packet_id : UInt32, name : String, mode : UInt8, *, with_display = true) : Bytes
+  build_packet(packet_id) do |io|
+    io.write name
+    io.write_byte mode
+    if mode != 1_u8
+      io.write Rosegold::TextComponent.new(name)
+      io.write 0_u32
+      io.write false
+    end
+  end
+end
+
+private def write_score(packet_id : UInt32, entity : String, objective : String, score : Int32 = 0) : Bytes
+  build_packet(packet_id) do |io|
+    io.write entity
+    io.write objective
+    io.write score.to_u32
+    io.write false
+    io.write false
+  end
+end
+
+private def write_reset_score(packet_id : UInt32, entity : String, objective : String?) : Bytes
+  build_packet(packet_id) do |io|
+    io.write entity
+    if objective
+      io.write true
+      io.write objective
+    else
+      io.write false
+    end
+  end
+end
+
+private def write_display(packet_id : UInt32, position : UInt32, objective : String) : Bytes
+  build_packet(packet_id) do |io|
+    io.write position
+    io.write objective
+  end
+end
+
+private def write_team(packet_id : UInt32, name : String, method : UInt8, &) : Bytes
+  build_packet(packet_id) do |io|
+    io.write name
+    io.write_byte method
+    yield io
+  end
+end
+
+Spectator.describe Rosegold::Spectate::ScoreboardCache do
+  let(packet_ids) { Rosegold::Spectate::ScoreboardCache::PROTOCOL_PACKET_IDS[774_u32] }
+  subject(cache) { Rosegold::Spectate::ScoreboardCache.new(packet_ids) }
+
+  describe "#captures?" do
+    it "matches configured packet IDs" do
+      packet_ids.values.each do |id|
+        expect(cache.captures?(id)).to be_true
+      end
+    end
+
+    it "rejects unknown packet IDs" do
+      expect(cache.captures?(0x01_u32)).to be_false
+    end
+  end
+
+  describe "objectives" do
+    it "caches a create" do
+      bytes = write_objective(packet_ids[:objective], "obj1", 0_u8)
+      cache.capture(bytes)
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to eq([bytes])
+    end
+
+    it "replaces a create with a mode=2 update" do
+      cache.capture(write_objective(packet_ids[:objective], "obj1", 0_u8))
+      update_bytes = write_objective(packet_ids[:objective], "obj1", 2_u8)
+      cache.capture(update_bytes)
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to eq([update_bytes])
+    end
+
+    it "removes an objective on mode=1" do
+      cache.capture(write_objective(packet_ids[:objective], "obj1", 0_u8))
+      cache.capture(write_objective(packet_ids[:objective], "obj1", 1_u8))
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to be_empty
+    end
+  end
+
+  describe "scores" do
+    it "caches a score per (entity, objective)" do
+      bytes = write_score(packet_ids[:score], "Alice", "obj1", 5)
+      cache.capture(bytes)
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to eq([bytes])
+    end
+
+    it "overwrites a prior score for the same (entity, objective)" do
+      cache.capture(write_score(packet_ids[:score], "Alice", "obj1", 5))
+      updated = write_score(packet_ids[:score], "Alice", "obj1", 10)
+      cache.capture(updated)
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to eq([updated])
+    end
+
+    it "removes a specific score with reset_score and objective name" do
+      cache.capture(write_score(packet_ids[:score], "Alice", "obj1", 5))
+      cache.capture(write_score(packet_ids[:score], "Alice", "obj2", 7))
+      cache.capture(write_reset_score(packet_ids[:reset_score], "Alice", "obj1"))
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed.size).to eq(1)
+    end
+
+    it "removes all scores for an entity when objective name omitted" do
+      cache.capture(write_score(packet_ids[:score], "Alice", "obj1", 5))
+      cache.capture(write_score(packet_ids[:score], "Alice", "obj2", 7))
+      cache.capture(write_score(packet_ids[:score], "Bob", "obj1", 3))
+      cache.capture(write_reset_score(packet_ids[:reset_score], "Alice", nil))
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed.size).to eq(1)
+    end
+  end
+
+  describe "display" do
+    it "caches latest display per position" do
+      first = write_display(packet_ids[:display], 1_u32, "obj1")
+      cache.capture(first)
+      second = write_display(packet_ids[:display], 1_u32, "obj2")
+      cache.capture(second)
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to eq([second])
+    end
+  end
+
+  describe "teams" do
+    it "caches create" do
+      bytes = write_team(packet_ids[:teams], "team1", 0_u8) { |_io| }
+      cache.capture(bytes)
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to eq([bytes])
+    end
+
+    it "removes team on method=1" do
+      cache.capture(write_team(packet_ids[:teams], "team1", 0_u8) { |_io| })
+      cache.capture(write_team(packet_ids[:teams], "team1", 1_u8) { |_io| })
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to be_empty
+    end
+
+    it "preserves entity changes alongside create" do
+      create = write_team(packet_ids[:teams], "team1", 0_u8) { |_io| }
+      add = write_team(packet_ids[:teams], "team1", 3_u8) { |_io| }
+      cache.capture(create)
+      cache.capture(add)
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to eq([create, add])
+    end
+
+    it "clears entity changes on team remove" do
+      cache.capture(write_team(packet_ids[:teams], "team1", 0_u8) { |_io| })
+      cache.capture(write_team(packet_ids[:teams], "team1", 3_u8) { |_io| })
+      cache.capture(write_team(packet_ids[:teams], "team1", 1_u8) { |_io| })
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to be_empty
+    end
+  end
+
+  describe "replay order" do
+    it "yields objectives, teams, scores, then displays" do
+      objective = write_objective(packet_ids[:objective], "obj1", 0_u8)
+      team = write_team(packet_ids[:teams], "team1", 0_u8) { |_io| }
+      score = write_score(packet_ids[:score], "Alice", "obj1", 5)
+      display = write_display(packet_ids[:display], 1_u32, "obj1")
+
+      cache.capture(score)
+      cache.capture(display)
+      cache.capture(team)
+      cache.capture(objective)
+
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to eq([objective, team, score, display])
+    end
+  end
+
+  describe "#clear" do
+    it "drops all cached state" do
+      cache.capture(write_objective(packet_ids[:objective], "obj1", 0_u8))
+      cache.capture(write_score(packet_ids[:score], "Alice", "obj1", 5))
+      cache.clear
+      replayed = [] of Bytes
+      cache.replay { |relayed| replayed << relayed }
+      expect(replayed).to be_empty
+    end
+  end
+
+  describe ".for_protocol?" do
+    it "returns a cache for supported protocols" do
+      [772_u32, 774_u32, 775_u32].each do |proto|
+        expect(Rosegold::Spectate::ScoreboardCache.for_protocol?(proto)).not_to be_nil
+      end
+    end
+
+    it "returns nil for unsupported protocols" do
+      expect(Rosegold::Spectate::ScoreboardCache.for_protocol?(999_u32)).to be_nil
+    end
+  end
+end

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -23,6 +23,7 @@ module Rosegold::Spectate::PlaySession
     setup_command_suggestions_listener
     setup_raw_packet_relay
     send_cached_commands
+    send_cached_scoreboard
     start_keep_alive_sender
   end
 
@@ -31,6 +32,17 @@ module Rosegold::Spectate::PlaySession
     return unless bytes
     Log.debug { "Replaying cached Commands packet (#{bytes.size} bytes) to spectator" }
     send_packet(Rosegold::Clientbound::RawPacket.new(bytes))
+  end
+
+  private def send_cached_scoreboard
+    cache = @spectate_server.scoreboard_cache
+    return unless cache
+    count = 0
+    cache.replay do |bytes|
+      send_packet(Rosegold::Clientbound::RawPacket.new(bytes))
+      count += 1
+    end
+    Log.debug { "Replayed #{count} cached scoreboard packets to spectator" } if count > 0
   end
 
   private def setup_command_suggestions_listener

--- a/src/rosegold/spectate/scoreboard_cache.cr
+++ b/src/rosegold/spectate/scoreboard_cache.cr
@@ -1,0 +1,159 @@
+require "../../minecraft/io"
+
+class Rosegold::Spectate::ScoreboardCache
+  Log = ::Log.for self
+
+  PROTOCOL_PACKET_IDS = {
+    772_u32 => {objective: 0x63_u32, score: 0x67_u32, display: 0x5B_u32, reset_score: 0x48_u32, teams: 0x66_u32},
+    774_u32 => {objective: 0x68_u32, score: 0x6C_u32, display: 0x60_u32, reset_score: 0x4D_u32, teams: 0x6B_u32},
+    775_u32 => {objective: 0x6A_u32, score: 0x6E_u32, display: 0x62_u32, reset_score: 0x4F_u32, teams: 0x6D_u32},
+  }
+
+  alias PacketIds = NamedTuple(objective: UInt32, score: UInt32, display: UInt32, reset_score: UInt32, teams: UInt32)
+
+  getter packet_ids : PacketIds
+
+  @objectives = {} of String => Bytes
+  @scores = {} of Tuple(String, String) => Bytes
+  @displays = {} of UInt32 => Bytes
+  @teams = {} of String => Tuple(Bytes?, Array(Bytes))
+  @mutex = Mutex.new
+
+  def initialize(@packet_ids : PacketIds)
+  end
+
+  def self.for_protocol?(protocol : UInt32) : ScoreboardCache?
+    ids = PROTOCOL_PACKET_IDS[protocol]?
+    ids ? new(ids) : nil
+  end
+
+  def clear
+    @mutex.synchronize do
+      @objectives.clear
+      @scores.clear
+      @displays.clear
+      @teams.clear
+    end
+  end
+
+  def captures?(packet_id : UInt32) : Bool
+    @packet_ids.values.includes?(packet_id)
+  end
+
+  def capture(raw_bytes : Bytes) : Bool
+    io = Minecraft::IO::Memory.new(raw_bytes, writeable: false)
+    packet_id = io.read_var_int
+
+    case packet_id
+    when @packet_ids[:objective]
+      capture_objective(io, raw_bytes)
+    when @packet_ids[:score]
+      capture_score(io, raw_bytes)
+    when @packet_ids[:display]
+      capture_display(io, raw_bytes)
+    when @packet_ids[:reset_score]
+      capture_reset_score(io)
+    when @packet_ids[:teams]
+      capture_teams(io, raw_bytes)
+    else
+      return false
+    end
+    true
+  rescue ex
+    Log.debug { "Failed to parse scoreboard packet: #{ex}" }
+    false
+  end
+
+  def replay(& : Bytes -> _)
+    snapshot = @mutex.synchronize { take_snapshot }
+
+    snapshot[:objectives].each { |bytes| yield bytes }
+    snapshot[:teams].each do |(create, changes)|
+      yield create if create
+      changes.each { |bytes| yield bytes }
+    end
+    snapshot[:scores].each { |bytes| yield bytes }
+    snapshot[:displays].each { |bytes| yield bytes }
+  end
+
+  def size : Int32
+    @mutex.synchronize do
+      total = @objectives.size + @scores.size + @displays.size
+      @teams.each_value { |(_, changes)| total += changes.size + 1 }
+      total
+    end
+  end
+
+  private def take_snapshot
+    {
+      objectives: @objectives.values.dup,
+      teams:      @teams.values.map { |(create, changes)| {create, changes.dup} },
+      scores:     @scores.values.dup,
+      displays:   @displays.values.dup,
+    }
+  end
+
+  private def capture_objective(io, raw_bytes)
+    name = io.read_var_string
+    mode = io.read_byte
+    @mutex.synchronize do
+      if mode == 1_u8
+        @objectives.delete(name)
+      else
+        @objectives[name] = raw_bytes
+      end
+    end
+  end
+
+  private def capture_score(io, raw_bytes)
+    entity = io.read_var_string
+    objective = io.read_var_string
+    @mutex.synchronize do
+      @scores[{objective, entity}] = raw_bytes
+    end
+  end
+
+  private def capture_display(io, raw_bytes)
+    position = io.read_var_int
+    @mutex.synchronize do
+      @displays[position] = raw_bytes
+    end
+  end
+
+  private def capture_reset_score(io)
+    entity = io.read_var_string
+    has_objective = io.read_bool
+    objective_name = has_objective ? io.read_var_string : nil
+    @mutex.synchronize do
+      if objective_name
+        @scores.delete({objective_name, entity})
+      else
+        @scores.reject! { |key, _| key[1] == entity }
+      end
+    end
+  end
+
+  private def capture_teams(io, raw_bytes)
+    name = io.read_var_string
+    method = io.read_byte
+    @mutex.synchronize do
+      case method
+      when 0_u8
+        @teams[name] = {raw_bytes, [] of Bytes}
+      when 1_u8
+        @teams.delete(name)
+      when 2_u8
+        existing = @teams[name]?
+        changes = existing ? existing[1] : ([] of Bytes)
+        @teams[name] = {raw_bytes, changes}
+      when 3_u8, 4_u8
+        existing = @teams[name]?
+        if existing
+          existing[1] << raw_bytes
+        else
+          @teams[name] = {nil, [raw_bytes]}
+        end
+      end
+    end
+  end
+end

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -4,6 +4,7 @@ require "../packets/*"
 require "../world/*"
 require "../../minecraft/nbt"
 require "../../minecraft/io"
+require "./scoreboard_cache"
 
 # Forward declaration to avoid circular dependency
 class Rosegold::Client; end
@@ -113,7 +114,9 @@ class Rosegold::Spectate::Server
   property connections = Array(Connection).new
 
   getter cached_commands_bytes : Bytes? = nil
+  getter scoreboard_cache : ScoreboardCache? = nil
   @bot_commands_handler_id : UUID? = nil
+  @bot_scoreboard_handler_id : UUID? = nil
 
   @next_command_suggestion_tid = Atomic(UInt32).new(0_u32)
 
@@ -181,14 +184,19 @@ class Rosegold::Spectate::Server
 
   def attach_client(client : Rosegold::Client)
     stop_caching_commands
+    stop_caching_scoreboard
     @cached_commands_bytes = nil
+    @scoreboard_cache = nil
     @client = client
     start_caching_commands(client)
+    start_caching_scoreboard(client)
   end
 
   def detach_client
     stop_caching_commands
+    stop_caching_scoreboard
     @cached_commands_bytes = nil
+    @scoreboard_cache = nil
     @client = nil
   end
 
@@ -209,5 +217,26 @@ class Rosegold::Spectate::Server
       client.off(Rosegold::Event::RawPacket, id)
     end
     @bot_commands_handler_id = nil
+  end
+
+  private def start_caching_scoreboard(client : Rosegold::Client)
+    cache = ScoreboardCache.for_protocol?(client.protocol_version)
+    return unless cache
+    @scoreboard_cache = cache
+
+    @bot_scoreboard_handler_id = client.on(Rosegold::Event::RawPacket) do |event|
+      next unless client.current_protocol_state.play?
+      first_byte = event.bytes[0]?
+      next unless first_byte
+      next unless cache.captures?(first_byte.to_u32)
+      cache.capture(event.bytes)
+    end
+  end
+
+  private def stop_caching_scoreboard
+    if (client = @client) && (id = @bot_scoreboard_handler_id)
+      client.off(Rosegold::Event::RawPacket, id)
+    end
+    @bot_scoreboard_handler_id = nil
   end
 end


### PR DESCRIPTION
## Summary
- Scoreboard packets were already forwarded live via the raw relay, but spectators joining after the bot saw nothing because the server sent initial state to the bot before they connected.
- Adds a `ScoreboardCache` that parses just enough of each scoreboard packet (objective, score, display, reset_score, teams) to key them, then stores the raw bytes for replay.
- Replays cached state in the order objectives → teams → scores → displays when a spectator transitions into the spectating phase.
- Cache is scoped to the active bot connection and cleared on attach/detach.

Closes #327

## Test plan
- [x] `crystal spec spec/rosegold/spectate/scoreboard_cache_spec.cr` — 18 examples covering creates, updates, removes, reset_score (with and without objective name), team entity changes, replay ordering, and protocol selection.
- [x] Full unit suite: 432 examples, 0 failures.
- [x] `bin/ameba src/rosegold/spectate/ spec/rosegold/spectate/` clean.
- [ ] Manual: connect a spectator to a bot that already has a sidebar scoreboard; verify the sidebar appears immediately.