### PR TITLE
Fix ProtocolState predicate compile error

### DIFF
--- a/spec/packets/protocol_state_spec.cr
+++ b/spec/packets/protocol_state_spec.cr
@@ -1,0 +1,30 @@
+require "../spec_helper"
+
+Spectator.describe Rosegold::ProtocolState do
+  describe "predicates" do
+    it "identifies HANDSHAKING" do
+      expect(Rosegold::ProtocolState::HANDSHAKING.handshaking?).to be_true
+      expect(Rosegold::ProtocolState::HANDSHAKING.play?).to be_false
+    end
+
+    it "identifies STATUS" do
+      expect(Rosegold::ProtocolState::STATUS.status?).to be_true
+      expect(Rosegold::ProtocolState::STATUS.login?).to be_false
+    end
+
+    it "identifies LOGIN" do
+      expect(Rosegold::ProtocolState::LOGIN.login?).to be_true
+      expect(Rosegold::ProtocolState::LOGIN.configuration?).to be_false
+    end
+
+    it "identifies CONFIGURATION" do
+      expect(Rosegold::ProtocolState::CONFIGURATION.configuration?).to be_true
+      expect(Rosegold::ProtocolState::CONFIGURATION.play?).to be_false
+    end
+
+    it "identifies PLAY" do
+      expect(Rosegold::ProtocolState::PLAY.play?).to be_true
+      expect(Rosegold::ProtocolState::PLAY.handshaking?).to be_false
+    end
+  end
+end

--- a/src/rosegold/packets/packet.cr
+++ b/src/rosegold/packets/packet.cr
@@ -86,6 +86,26 @@ class Rosegold::ProtocolState
   def initialize(@name)
   end
 
+  def handshaking? : Bool
+    self == HANDSHAKING
+  end
+
+  def status? : Bool
+    self == STATUS
+  end
+
+  def login? : Bool
+    self == LOGIN
+  end
+
+  def configuration? : Bool
+    self == CONFIGURATION
+  end
+
+  def play? : Bool
+    self == PLAY
+  end
+
   def self.register(packet : Packet.class)
     packet.state.register packet
   end

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -225,7 +225,7 @@ class Rosegold::Spectate::Server
     @scoreboard_cache = cache
 
     @bot_scoreboard_handler_id = client.on(Rosegold::Event::RawPacket) do |event|
-      next unless client.current_protocol_state.play?
+      next unless client.current_protocol_state == Rosegold::ProtocolState::PLAY
       first_byte = event.bytes[0]?
       next unless first_byte
       next unless cache.captures?(first_byte.to_u32)

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -225,7 +225,7 @@ class Rosegold::Spectate::Server
     @scoreboard_cache = cache
 
     @bot_scoreboard_handler_id = client.on(Rosegold::Event::RawPacket) do |event|
-      next unless client.current_protocol_state == Rosegold::ProtocolState::PLAY
+      next unless client.current_protocol_state.play?
       first_byte = event.bytes[0]?
       next unless first_byte
       next unless cache.captures?(first_byte.to_u32)


### PR DESCRIPTION
## Summary
- The scoreboard cache handler added in 733f7cf called `client.current_protocol_state.play?`, but `Rosegold::ProtocolState` is a regular class with singleton constants (`PLAY`, `LOGIN`, ...), not an enum, so no `play?` predicate exists.
- This compiled inside rosegold itself (the closure body was never concretized in any local entry point) but broke downstream projects whose call graph forces the block to be type-checked, e.g. estalia-headless:
  ```
  Error: undefined method 'play?' for Rosegold::ProtocolState
  ```
- Two commits: (1) immediate fix using `== ProtocolState::PLAY` so downstream unblocks, (2) refactor adds `handshaking?`/`status?`/`login?`/`configuration?`/`play?` predicates on `ProtocolState` and switches the call site back to the idiomatic `.play?` form.

## Test plan
- [x] `crystal build --no-codegen src/rosegold.cr` — clean
- [x] `crystal spec spec/packets/protocol_state_spec.cr` — 5 examples, 0 failures
- [x] `bin/ameba` on modified files — no failures
- [ ] Verify downstream estalia-headless compiles after pulling