### PR TITLE
Stop sending PLAY packets during configuration

### DIFF
--- a/spec/integration/server_switch_spec.cr
+++ b/spec/integration/server_switch_spec.cr
@@ -1,0 +1,47 @@
+require "../spec_helper"
+
+# Test helper: inject an in-memory connection so send_packet! can be exercised
+# without a real server.
+module Rosegold
+  class Client
+    def inject_test_connection(conn : Connection::Client)
+      @connection = conn
+    end
+  end
+end
+
+# Regression: on a Velocity server switch (e.g. CivMC queue→main via ajqueue)
+# the server sends StartConfiguration and we flip to CONFIGURATION. Vanilla
+# stops ticking during configuration; sending a PLAY packet (ClientTickEnd,
+# serverbound 0x0C) while the proxy has us in CONFIGURATION is decoded as an
+# unknown config packet and the proxy drops us with "An internal error
+# occurred in your connection."
+Spectator.describe "Server switch PLAY/CONFIGURATION packet gating" do
+  def build_client(state : Rosegold::ProtocolState)
+    io = Minecraft::IO::Memory.new
+    conn = Rosegold::Connection::Client.new(io, state, Rosegold::Client.protocol_version)
+    client = Rosegold::Client.new("localhost", 25565,
+      offline: {uuid: "00000000-0000-0000-0000-000000000000", username: "test"})
+    client.inject_test_connection(conn)
+    client.set_protocol_state(state)
+    {client, io}
+  end
+
+  it "drops a PLAY packet (ClientTickEnd) while in CONFIGURATION state" do
+    client, io = build_client(Rosegold::ProtocolState::CONFIGURATION)
+    client.send_packet!(Rosegold::Serverbound::ClientTickEnd.new)
+    expect(io.size).to eq(0)
+  end
+
+  it "still sends CONFIGURATION packets while in CONFIGURATION state" do
+    client, io = build_client(Rosegold::ProtocolState::CONFIGURATION)
+    client.send_packet!(Rosegold::Serverbound::FinishConfiguration.new)
+    expect(io.size).to be > 0
+  end
+
+  it "sends PLAY packets normally while in PLAY state" do
+    client, io = build_client(Rosegold::ProtocolState::PLAY)
+    client.send_packet!(Rosegold::Serverbound::ClientTickEnd.new)
+    expect(io.size).to be > 0
+  end
+end

--- a/src/rosegold/client.cr
+++ b/src/rosegold/client.cr
@@ -265,7 +265,11 @@ class Rosegold::Client < Rosegold::EventEmitter
                         true
                       end
 
-        if should_tick
+        # The game tick only runs in PLAY. During a server switch the proxy
+        # puts us through PLAY→CONFIGURATION→PLAY; vanilla stops ticking while
+        # configuring, and any PLAY packet sent in CONFIGURATION (e.g.
+        # ClientTickEnd) makes Velocity drop the connection.
+        if should_tick && current_protocol_state == ProtocolState::PLAY
           begin
             interactions.tick
             physics.tick
@@ -432,6 +436,13 @@ class Rosegold::Client < Rosegold::EventEmitter
   # a EncryptionResponse has been sent.
   def send_packet!(packet : Serverbound::Packet)
     raise NotConnected.new unless connected?
+    # Mirror vanilla's Netty codec swap: a PLAY packet leaking out while we are
+    # not in PLAY (e.g. a straggler queued during a server switch) makes the
+    # proxy drop the connection with "internal error". Drop it instead.
+    if packet.class.state == ProtocolState::PLAY && current_protocol_state != ProtocolState::PLAY
+      Log.warn { "Dropping #{packet.class} send in #{current_protocol_state.name} state" }
+      return
+    end
     Log.trace { "[#{current_protocol_state.name}] SEND #{packet}" }
     connection.send_packet packet
   end


### PR DESCRIPTION
## Problem

Bots disconnect during a proxy server switch on CivMC (queue → main, via ajqueue). The log shows the connection moving to CONFIGURATION and then being dropped ~200ms later:

```
Sent AcknowledgeConfiguration packet
Paused physics during configuration transition
Start configuration received, transitioning to CONFIGURATION state
Disconnected: An internal error occurred in your connection.
```

## Root cause

The bot is fully spawned in PLAY with the 20 TPS tick loop running. Every tick it unconditionally sends `ClientTickEnd` (PLAY serverbound `0x0C`). When the server sends `StartConfiguration`, the bot acks and flips to CONFIGURATION — but the tick loop keeps running and keeps sending `ClientTickEnd`.

Velocity tolerates unknown serverbound packet ids **only in the PLAY state** (`MinecraftDecoder.tryDecode`). In CONFIGURATION, `0x0C` is past the end of the config serverbound table, so it throws a decode error that surfaces as `ClientConfigSessionHandler.exception()` → `"An internal error occurred in your connection."` Timing matches: state → CONFIGURATION at T+0, disconnect at T+203ms (~4 ticks of `ClientTickEnd`).

Verified against the protocol tables (1.21.8 / 772), decompiled vanilla source, and Velocity source.

## Fix

- Gate the tick loop so it only runs game-tick logic and sends `ClientTickEnd` while in PLAY — matching the vanilla client, which stops ticking during configuration.
- Defense in depth: `send_packet!` now drops any PLAY-category packet sent while not in PLAY, mirroring vanilla's Netty codec swap. This also covers stragglers (queued movement, scripts acting mid-switch). `AcknowledgeConfiguration` is unaffected since it is sent while the state is still PLAY.

After the fix, configuration completes normally and physics resumes via `handle_reset` on the following Login/SynchronizePlayerPosition.

## Test

`spec/integration/server_switch_spec.cr` injects an in-memory connection and asserts `ClientTickEnd` is dropped in CONFIGURATION while config packets still send and PLAY packets send in PLAY. Confirmed it fails without the fix (the packet leaks, `io.size` = 2) and passes with it.

Checks: `crystal tool format`, `crystal build --no-codegen`, `bin/ameba`, new spec (3/3), existing `configuration_flow_spec` (8/8).