### PR TITLE
Raise ContainerOpenError when a container fails to open

### DIFF
--- a/spec/integration/inventory_spec.cr
+++ b/spec/integration/inventory_spec.cr
@@ -759,6 +759,7 @@ Spectator.describe "Rosegold::Bot inventory" do
             admin.wait_tick
 
             bot.pitch = 90
+            bot.wait_ticks 2
             bot.use_hand
             bot.wait_for Rosegold::Clientbound::SetContainerContent
 

--- a/src/rosegold/bot.cr
+++ b/src/rosegold/bot.cr
@@ -295,6 +295,8 @@ class Rosegold::Bot < Rosegold::EventEmitter
     stop_using_hand
   end
 
+  class ContainerOpenError < Exception; end
+
   # Opens a container (chest, barrel, etc.) and yields control for interaction.
   # Automatically uses the main hand, waits for container content to load,
   # executes the provided block, then closes the container.
@@ -307,7 +309,11 @@ class Rosegold::Bot < Rosegold::EventEmitter
   # ```
   # Caller must already be looking at the container block.
   def open_container(timeout : Time::Span = 5.seconds, &)
-    wait_for(Rosegold::Clientbound::SetContainerContent, timeout: timeout) { use_hand }
+    begin
+      wait_for(Rosegold::Clientbound::SetContainerContent, timeout: timeout) { use_hand }
+    rescue ex
+      raise ContainerOpenError.new("Failed to open container: #{ex.message}")
+    end
     yield
     wait_tick
     inventory.close
@@ -328,7 +334,11 @@ class Rosegold::Bot < Rosegold::EventEmitter
   # ```
   # Caller must already be looking at the container block.
   def open_container_handle(timeout : Time::Span = 5.seconds, &)
-    wait_for(Rosegold::Clientbound::SetContainerContent, timeout: timeout) { use_hand }
+    begin
+      wait_for(Rosegold::Clientbound::SetContainerContent, timeout: timeout) { use_hand }
+    rescue ex
+      raise ContainerOpenError.new("Failed to open container: #{ex.message}")
+    end
     handle = ContainerHandle.new(client, client.container_menu)
     begin
       yield handle
@@ -339,7 +349,11 @@ class Rosegold::Bot < Rosegold::EventEmitter
   end
 
   def open_container_handle(command : String, timeout : Time::Span = 5.seconds, &)
-    wait_for(Rosegold::Clientbound::SetContainerContent, timeout: timeout) { chat(command) }
+    begin
+      wait_for(Rosegold::Clientbound::SetContainerContent, timeout: timeout) { chat(command) }
+    rescue ex
+      raise ContainerOpenError.new("Failed to open container: #{ex.message}")
+    end
     handle = ContainerHandle.new(client, client.container_menu)
     begin
       yield handle


### PR DESCRIPTION
## What

`open_container` and the `open_container_handle` helpers wait for `SetContainerContent` after triggering the open. On timeout, the block-form `wait_for` raised a bare `RuntimeError`, so callers couldn't tell a failed container open apart from any other runtime error.

This wraps the wait in a typed `Rosegold::Bot::ContainerOpenError`. A failed open is now catchable on its own, matching the existing `CraftingError` and `ItemNotFoundError` pattern.

## Why

Without a typed error, recovery and retry logic had to rescue everything or string-match the message. The custom exception gives callers a clean handle.