### PR TITLE
Fix raytrace dropping rays that hit a block edge or corner

### DIFF
--- a/spec/rosegold/control/raytrace_spec.cr
+++ b/spec/rosegold/control/raytrace_spec.cr
@@ -1,0 +1,38 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Raytrace do
+  # Unit cube at the origin.
+  let(box) { Rosegold::AABBd.new(0.0, 0.0, 0.0, 1.0, 1.0, 1.0) }
+
+  describe ".raytrace" do
+    it "registers a ray that grazes an edge of the box" do
+      # Eye outside on x and z, level on y; aimed straight at the (x=0,z=0) edge.
+      start = Rosegold::Vec3d.new(-1.0, 0.5, -1.0)
+      delta = Rosegold::Vec3d.new(2.0, 0.0, 2.0)
+      result = Rosegold::Raytrace.raytrace(start, delta, [box])
+      expect(result).not_to be_nil
+    end
+
+    it "registers a ray that grazes a corner of the box" do
+      # Eye outside on all three axes, aimed at the (0,0,0) corner.
+      start = Rosegold::Vec3d.new(-1.0, -1.0, -1.0)
+      delta = Rosegold::Vec3d.new(2.0, 2.0, 2.0)
+      result = Rosegold::Raytrace.raytrace(start, delta, [box])
+      expect(result).not_to be_nil
+    end
+
+    it "still hits a face squarely" do
+      start = Rosegold::Vec3d.new(-1.0, 0.5, 0.5)
+      delta = Rosegold::Vec3d.new(2.0, 0.0, 0.0)
+      result = Rosegold::Raytrace.raytrace(start, delta, [box])
+      expect(result).not_to be_nil
+    end
+
+    it "still misses a box the ray never reaches" do
+      start = Rosegold::Vec3d.new(-1.0, 5.0, 0.5)
+      delta = Rosegold::Vec3d.new(2.0, 0.0, 0.0)
+      result = Rosegold::Raytrace.raytrace(start, delta, [box])
+      expect(result).to be_nil
+    end
+  end
+end

--- a/src/rosegold/control/raytrace.cr
+++ b/src/rosegold/control/raytrace.cr
@@ -2,6 +2,16 @@ require "../world/aabb"
 require "../world/vec3"
 
 module Rosegold::Raytrace
+  # A ray aimed at a block's closest point lands on an edge/corner of its hitbox,
+  # and look quantization can put the hit a hair outside the face. Tolerate that so
+  # grazing hits register instead of being dropped (mirrors vanilla's inflated clip);
+  # far smaller than the 1/16 gap between blocks, so it can't hit a neighbor.
+  EDGE_EPSILON = 1e-4
+
+  private def self.within?(value : Float64, lo : Float64, hi : Float64) : Bool
+    lo - EDGE_EPSILON <= value && value <= hi + EDGE_EPSILON
+  end
+
   struct Ray
     getter start : Vec3d, delta : Vec3d
 
@@ -79,9 +89,9 @@ module Rosegold::Raytrace
     scalar = (plane_coord - start_coord) / delta_coord
     return nil if !(0 <= scalar && scalar < 1) # plane too far behind/ahead of ray
     hit = ray.start + ray.delta * scalar
-    return nil if face != BlockFace::East && face != BlockFace::West && !(box.min.x < hit.x && hit.x < box.max.x)
-    return nil if face != BlockFace::Top && face != BlockFace::Bottom && !(box.min.y < hit.y && hit.y < box.max.y)
-    return nil if face != BlockFace::South && face != BlockFace::North && !(box.min.z < hit.z && hit.z < box.max.z)
+    return nil if face != BlockFace::East && face != BlockFace::West && !within?(hit.x, box.min.x, box.max.x)
+    return nil if face != BlockFace::Top && face != BlockFace::Bottom && !within?(hit.y, box.min.y, box.max.y)
+    return nil if face != BlockFace::South && face != BlockFace::North && !within?(hit.z, box.min.z, box.max.z)
     {scalar, hit}
   end
 end


### PR DESCRIPTION
## Problem

`Raytrace.intersect_plane` validates the two axes perpendicular to the candidate face with **strict** `<` bounds:

```crystal
return nil if ... && !(box.min.x < hit.x && hit.x < box.max.x)
```

So a ray whose intersection lands exactly on an **edge or corner** of a block's hitbox (where `hit.x == box.min.x`) is rejected as a miss.

This shows up when aiming at the point of a block **closest** to the eye — the natural choice for reaching a block near the edge of range. If the block is offset diagonally (e.g. a chest to the side of or above the player), its closest reachable point *is* a corner/edge, so the ray grazes the boundary and the interaction silently fails — even though a real client standing in the same spot, aiming mid-face, opens it fine.

## Fix

Tolerate the boundary with a small epsilon (`1e-4`) in the perpendicular-axis containment checks, mirroring vanilla's slightly-inflated AABB clip. It is far smaller than the gap between adjacent blocks, so a grazing hit registers without ever matching a neighbor.

## Test

Adds `spec/rosegold/control/raytrace_spec.cr`: edge and corner rays now register, while a square face hit still hits and a ray that never reaches the box still misses.