### PR TITLE
Match vanilla item-use after block right-click

### DIFF
--- a/src/rosegold/bot.cr
+++ b/src/rosegold/bot.cr
@@ -314,9 +314,13 @@ class Rosegold::Bot < Rosegold::EventEmitter
     rescue ex
       raise ContainerOpenError.new("Failed to open container: #{ex.message}")
     end
-    yield
-    wait_tick
-    inventory.close
+    # A chest left open desyncs the next world interaction, so close even on error.
+    begin
+      yield
+    ensure
+      wait_tick
+      inventory.close
+    end
   end
 
   # Opens a container and yields a ContainerHandle for typed interaction.

--- a/src/rosegold/control/interactions.cr
+++ b/src/rosegold/control/interactions.cr
@@ -181,11 +181,15 @@ class Rosegold::Interactions
         Log.debug { "Reached block: #{reached.block} at #{reached.intercept} face #{reached.face}" }
         place_block using_hand, reached
 
-        sequence = client.next_sequence
-        operation = BlockOperation.new(Vec3i::ORIGIN, :use)
-        client.pending_block_operations[sequence] = operation
+        # Sneaking with an item bypasses block-use, so the item is used against
+        # the block (the hopper-drain case). Vanilla skips UseItem otherwise.
+        if client.player.sneaking? && inventory.main_hand.present?
+          sequence = client.next_sequence
+          operation = BlockOperation.new(Vec3i::ORIGIN, :use)
+          client.pending_block_operations[sequence] = operation
 
-        send_packet Serverbound::UseItem.new using_hand, sequence, client.player.look.yaw, client.player.look.pitch
+          send_packet Serverbound::UseItem.new using_hand, sequence, client.player.look.yaw, client.player.look.pitch
+        end
       else
         Log.debug { "No block or entity reached" }
 


### PR DESCRIPTION
Right-clicking a block always sent both UseItemOn and UseItem. Vanilla only sends UseItem after UseItemOn when the block-use doesn't consume the click, so the extra packet drank or threw a held potion right after the block interaction. That broke server-side block-use plugins like the CivMC hopper potion-drain: the drain fired, then the stray UseItem spent the potion the wrong way.

Now UseItem only follows UseItemOn when sneaking with an item in hand, the one case where vanilla bypasses block-use and the item is used against the block instead. Not sneaking, an interactive block consumes the click and no UseItem follows, which also stops normal container opens from throwing a held potion.

The guard fires for sneak-placing a block too, where vanilla wouldn't. That path is rare here and harmless; full fidelity needs block-interactivity prediction, which this doesn't add.

Also closes the container from `open_container`'s ensure block so an error mid-interaction can't leave a chest open and desync the next world action.