### PR TITLE
Stop bot wall-stick on flush floors

### DIFF
--- a/spec/models/physics_collision_spec.cr
+++ b/spec/models/physics_collision_spec.cr
@@ -2,6 +2,53 @@ require "../spec_helper"
 require "../../src/rosegold/control/physics"
 require "../../src/rosegold/world/aabb"
 require "../../src/rosegold/world/vec3"
+require "../../src/rosegold/world/player"
+
+Spectator.describe "Physics horizontal movement on a flush floor" do
+  # Regression for a freeze observed on a real server: in a 2-tall corridor with a top-slab
+  # floor, the bot rests with feet exactly at the floor's top face (feet.y == 63.0). The
+  # floor block one step ahead is coplanar with the feet; with inclusive collision bounds
+  # its side face wrongly registers as a wall and horizontal velocity is zeroed, and the
+  # surrounding ceiling/wall geometry blocks the 0.6 auto-step from masking it. Vanilla
+  # (VoxelShape.collideX) shrinks the entity box inward by 1e-7 on the perpendicular axes,
+  # so a merely-touched surface never impedes perpendicular motion. Block coordinates and
+  # the start position are taken verbatim from the captured stuck frame; without the fix
+  # `movement.x` comes back 0.0 instead of the commanded -0.13.
+  it "does not wall-stick on the slab floor it stands on" do
+    grow_aabb = Rosegold::Player::DEFAULT_AABB.to_f64 * -1
+    full = Rosegold::AABBf.new(0_f32, 0_f32, 0_f32, 1_f32, 1_f32, 1_f32)
+    top_slab = Rosegold::AABBf.new(0_f32, 0.5_f32, 0_f32, 1_f32, 1_f32, 1_f32)
+    chest_a = Rosegold::AABBf.new(0.0625_f32, 0_f32, 0.0625_f32, 1_f32, 0.875_f32, 0.9375_f32)
+    chest_b = Rosegold::AABBf.new(0_f32, 0_f32, 0.0625_f32, 0.9375_f32, 0.875_f32, 0.9375_f32)
+
+    blocks = [
+      {4489, 62, -15890, top_slab}, {4489, 62, -15889, full}, {4489, 62, -15888, full},
+      {4489, 63, -15889, full}, {4489, 63, -15888, chest_a}, {4489, 64, -15889, full}, {4489, 64, -15888, chest_a},
+      {4489, 65, -15892, full}, {4489, 65, -15891, full}, {4489, 65, -15890, full}, {4489, 65, -15889, full},
+      {4490, 62, -15892, top_slab}, {4490, 62, -15891, top_slab}, {4490, 62, -15890, top_slab}, {4490, 62, -15889, full}, {4490, 62, -15888, full},
+      {4490, 63, -15889, full}, {4490, 63, -15888, chest_b}, {4490, 64, -15889, full}, {4490, 64, -15888, chest_b},
+      {4490, 65, -15892, full}, {4490, 65, -15891, full}, {4490, 65, -15890, full}, {4490, 65, -15889, full},
+      {4491, 62, -15890, top_slab}, {4491, 62, -15889, full}, {4491, 62, -15888, full},
+      {4491, 63, -15889, full}, {4491, 63, -15888, chest_a}, {4491, 64, -15889, full}, {4491, 64, -15888, chest_a},
+      {4491, 65, -15892, full}, {4491, 65, -15891, full}, {4491, 65, -15890, full}, {4491, 65, -15889, full},
+      {4492, 62, -15890, top_slab}, {4492, 62, -15889, full}, {4492, 62, -15888, full},
+      {4492, 63, -15889, full}, {4492, 63, -15888, chest_b}, {4492, 64, -15889, full}, {4492, 64, -15888, chest_b},
+      {4492, 65, -15889, full},
+      {4493, 62, -15890, top_slab}, {4493, 62, -15889, full}, {4493, 62, -15888, full},
+      {4493, 63, -15889, full}, {4493, 64, -15889, full}, {4493, 65, -15889, full},
+    ]
+    obstacles = blocks.map do |(x, y, z, shape)|
+      shape.to_f64.offset(x.to_f64, y.to_f64, z.to_f64).grow(grow_aabb)
+    end
+
+    start = Rosegold::Vec3d.new(4491.300000011921, 63.0, -15889.500000052583)
+    velocity = Rosegold::Vec3d.new(-0.13000001203703704, -0.0784, -8.347977526169494e-9)
+
+    movement, _ = Rosegold::Physics.predict_movement_collision(start, velocity, obstacles)
+
+    expect(movement.x).to be < -0.1
+  end
+end
 
 Spectator.describe "Physics collision with block above head" do
   it "AABB.contains? should not consider player inside block when at exact boundary" do

--- a/src/rosegold/control/physics.cr
+++ b/src/rosegold/control/physics.cr
@@ -874,7 +874,7 @@ class Rosegold::Physics
   # Slide along block faces in three dimensions.
   private def self.slide(start, velocity, obstacles)
     (1..3).each do
-      collision = Raytrace.raytrace start, velocity, obstacles
+      collision = Raytrace.raytrace start, velocity, obstacles, strict: true
       return velocity unless collision
       # slide parallel to this face
       coord = (collision.intercept - start).axis collision.face

--- a/src/rosegold/control/raytrace.cr
+++ b/src/rosegold/control/raytrace.cr
@@ -8,8 +8,19 @@ module Rosegold::Raytrace
   # far smaller than the 1/16 gap between blocks, so it can't hit a neighbor.
   EDGE_EPSILON = 1e-4
 
-  private def self.within?(value : Float64, lo : Float64, hi : Float64) : Bool
-    lo - EDGE_EPSILON <= value && value <= hi + EDGE_EPSILON
+  # Movement collision uses the opposite tolerance from block-aiming: the entity box is
+  # shrunk inward by 1e-7 on the perpendicular axes (matching vanilla VoxelShape.collideX),
+  # so a surface the entity merely *touches* — e.g. the floor it stands flush on, or the
+  # next floor block coplanar with its feet — does not impede perpendicular motion. Without
+  # this the bot wall-sticks on the top face it stands on (top slabs, full-block floors).
+  MOVE_EPSILON = 1e-7
+
+  private def self.within?(value : Float64, lo : Float64, hi : Float64, strict : Bool) : Bool
+    if strict
+      lo + MOVE_EPSILON <= value && value <= hi - MOVE_EPSILON
+    else
+      lo - EDGE_EPSILON <= value && value <= hi + EDGE_EPSILON
+    end
   end
 
   struct Ray
@@ -24,42 +35,44 @@ module Rosegold::Raytrace
     def initialize(@intercept : Vec3d, @box_nr : Int32, @face : BlockFace); end
   end
 
-  def self.raytrace(start : Vec3d, delta : Vec3d, boxes : Array(AABBd)) : Result?
-    raytrace(Ray.new(start, delta), boxes)
+  # `strict` selects movement-collision tolerance (touching != colliding); leave false for
+  # block-aiming, which wants the grazing tolerance.
+  def self.raytrace(start : Vec3d, delta : Vec3d, boxes : Array(AABBd), strict : Bool = false) : Result?
+    raytrace(Ray.new(start, delta), boxes, strict)
   end
 
-  def self.raytrace(ray : Ray, boxes : Array(AABBd)) : Result?
+  def self.raytrace(ray : Ray, boxes : Array(AABBd), strict : Bool = false) : Result?
     min_scalar = 1_f64
     min_result = nil
 
     if ray.delta.x < 0
       boxes.each_with_index do |box, box_nr|
-        min_scalar, min_result = better(ray, box, box.max.x, BlockFace::East, min_scalar, min_result, box_nr)
+        min_scalar, min_result = better(ray, box, box.max.x, BlockFace::East, min_scalar, min_result, box_nr, strict)
       end
     end
     if ray.delta.x > 0
       boxes.each_with_index do |box, box_nr|
-        min_scalar, min_result = better(ray, box, box.min.x, BlockFace::West, min_scalar, min_result, box_nr)
+        min_scalar, min_result = better(ray, box, box.min.x, BlockFace::West, min_scalar, min_result, box_nr, strict)
       end
     end
     if ray.delta.y < 0
       boxes.each_with_index do |box, box_nr|
-        min_scalar, min_result = better(ray, box, box.max.y, BlockFace::Top, min_scalar, min_result, box_nr)
+        min_scalar, min_result = better(ray, box, box.max.y, BlockFace::Top, min_scalar, min_result, box_nr, strict)
       end
     end
     if ray.delta.y > 0
       boxes.each_with_index do |box, box_nr|
-        min_scalar, min_result = better(ray, box, box.min.y, BlockFace::Bottom, min_scalar, min_result, box_nr)
+        min_scalar, min_result = better(ray, box, box.min.y, BlockFace::Bottom, min_scalar, min_result, box_nr, strict)
       end
     end
     if ray.delta.z < 0
       boxes.each_with_index do |box, box_nr|
-        min_scalar, min_result = better(ray, box, box.max.z, BlockFace::South, min_scalar, min_result, box_nr)
+        min_scalar, min_result = better(ray, box, box.max.z, BlockFace::South, min_scalar, min_result, box_nr, strict)
       end
     end
     if ray.delta.z > 0
       boxes.each_with_index do |box, box_nr|
-        min_scalar, min_result = better(ray, box, box.min.z, BlockFace::North, min_scalar, min_result, box_nr)
+        min_scalar, min_result = better(ray, box, box.min.z, BlockFace::North, min_scalar, min_result, box_nr, strict)
       end
     end
 
@@ -69,9 +82,9 @@ module Rosegold::Raytrace
   # TODO: rename this helper
   private def self.better(
     ray : Ray, box : AABBd, plane_coord : Float64, face : BlockFace,
-    min_scalar : Float64, min_result : Result?, box_nr : Int32,
+    min_scalar : Float64, min_result : Result?, box_nr : Int32, strict : Bool,
   ) : Tuple(Float64, Result?)
-    intersect_plane(ray, box, plane_coord, face).try do |scalar, hit|
+    intersect_plane(ray, box, plane_coord, face, strict).try do |scalar, hit|
       if scalar < min_scalar
         {scalar, Result.new(hit, box_nr, face)}
       else
@@ -81,7 +94,7 @@ module Rosegold::Raytrace
   end
 
   private def self.intersect_plane(
-    ray : Ray, box : AABBd, plane_coord : Float64, face : BlockFace,
+    ray : Ray, box : AABBd, plane_coord : Float64, face : BlockFace, strict : Bool,
   ) : Tuple(Float64, Vec3d)?
     delta_coord = ray.delta.axis(face)
     start_coord = ray.start.axis(face)
@@ -89,9 +102,9 @@ module Rosegold::Raytrace
     scalar = (plane_coord - start_coord) / delta_coord
     return nil if !(0 <= scalar && scalar < 1) # plane too far behind/ahead of ray
     hit = ray.start + ray.delta * scalar
-    return nil if face != BlockFace::East && face != BlockFace::West && !within?(hit.x, box.min.x, box.max.x)
-    return nil if face != BlockFace::Top && face != BlockFace::Bottom && !within?(hit.y, box.min.y, box.max.y)
-    return nil if face != BlockFace::South && face != BlockFace::North && !within?(hit.z, box.min.z, box.max.z)
+    return nil if face != BlockFace::East && face != BlockFace::West && !within?(hit.x, box.min.x, box.max.x, strict)
+    return nil if face != BlockFace::Top && face != BlockFace::Bottom && !within?(hit.y, box.min.y, box.max.y, strict)
+    return nil if face != BlockFace::South && face != BlockFace::North && !within?(hit.z, box.min.z, box.max.z, strict)
     {scalar, hit}
   end
 end


### PR DESCRIPTION
## What

Bots froze in place on certain block layouts, top-slab floors being the common one. The movement raytrace used inclusive collision bounds, so a floor block coplanar with the bot's feet registered its side face as a wall and zeroed horizontal velocity. On a top-slab floor the bot rests with feet exactly at the floor's top face, so the next block one step ahead would stop it dead.

## Fix

Movement collision now shrinks the entity box inward by 1e-7 on the perpendicular axes, matching vanilla `VoxelShape.collideX`. A surface the box merely touches no longer impedes perpendicular motion. Block-aiming keeps the old grazing tolerance, so reach is unchanged.

## Test

`spec/models/physics_collision_spec.cr` adds a regression built from a captured stuck frame on a real server (top-slab corridor). Without the fix `movement.x` comes back 0.0 instead of the commanded -0.13.