### PR TITLE
Disable Nagle on spectate sockets

### DIFF
--- a/src/rosegold/client.cr
+++ b/src/rosegold/client.cr
@@ -300,7 +300,9 @@ class Rosegold::Client < Rosegold::EventEmitter
 
     detect_protocol_version
 
-    io = Minecraft::IO::Wrap.new TCPSocket.new(host, port)
+    socket = TCPSocket.new(host, port)
+    socket.tcp_nodelay = true
+    io = Minecraft::IO::Wrap.new socket
     connection = @connection = Connection::Client.new io, ProtocolState::HANDSHAKING, protocol_version, self
     @current_protocol_state = ProtocolState::HANDSHAKING
     connection.handler.try &.on Event::Disconnected do |_event|
@@ -410,7 +412,9 @@ class Rosegold::Client < Rosegold::EventEmitter
   end
 
   def self.status(host : String, port : UInt16 = 25565)
-    io = Minecraft::IO::Wrap.new TCPSocket.new(host, port)
+    socket = TCPSocket.new(host, port)
+    socket.tcp_nodelay = true
+    io = Minecraft::IO::Wrap.new socket
     connection = Connection::Client.new io, ProtocolState::HANDSHAKING, Client.protocol_version
 
     connection.send_packet Serverbound::Handshake.new Client.protocol_version, host, port, 1

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -142,6 +142,7 @@ class Rosegold::Spectate::Server
           end
 
           enable_tcp_keepalive(client_socket)
+          enable_tcp_nodelay(client_socket)
 
           Log.info { "New spectator connection from #{client_socket.remote_address}" }
 
@@ -177,6 +178,12 @@ class Rosegold::Spectate::Server
     socket.tcp_keepalive_count = 3
   rescue ex
     Log.debug { "Failed to enable TCP keepalive: #{ex}" }
+  end
+
+  private def enable_tcp_nodelay(socket : TCPSocket)
+    socket.tcp_nodelay = true
+  rescue ex
+    Log.debug { "Failed to enable TCP nodelay: #{ex}" }
   end
 
   def attach_client(client : Rosegold::Client)


### PR DESCRIPTION
Item entities were looking jumpy and stuttery to spectate-server viewers, even though every relevant entity packet gets raw-forwarded straight from the real server. The vanilla client interpolates remote entities over 3 ticks, so verbatim forwarding should look just as smooth as connecting directly.

Cause: `tcp_nodelay` was never set anywhere. Small 20Hz entity move packets were getting coalesced by Nagle plus delayed ACKs, on both the spectator-facing socket and the bot's own upstream connection to the real server. That turns a steady stream into bursts, which starves the client's interpolation window and then makes it jump to catch up.

Fix: set `tcp_nodelay = true` on accepted spectator sockets in `server.cr` (same rescue-and-log pattern as the existing keepalive setup), and on the bot's upstream sockets in `client.cr` (both the main play connection and the status-ping connection).

I also checked whether `send_existing_entities` synthesizing SpawnEntity from bot-side state could desync from the raw-forwarded EntityPosition delta stream at spectate-join time. It can't: the bot's own entity positions are updated by applying the exact same delta math from the exact same packets that get forwarded, so the base position matches by construction. No reconciliation needed there.