### PR TITLE
Fix stuck Loading terrain when connecting early

### DIFF
--- a/spec/integration/spectate_server_spec.cr
+++ b/spec/integration/spectate_server_spec.cr
@@ -70,8 +70,9 @@ Spectator.describe "SpectateServer Integration" do
       begin
         spectator.connect
 
+        # Lobby serves exactly one empty chunk; spectating serves a render-distance square
         deadline = Time.instant + 15.seconds
-        until (spectator.player.entity_id != 0_u64 && spectator.dimension_for_test.chunks.size > 0) || Time.instant > deadline
+        until (spectator.player.entity_id != 0_u64 && spectator.dimension_for_test.chunks.size > 1) || Time.instant > deadline
           sleep 10.milliseconds
         end
 
@@ -80,7 +81,7 @@ Spectator.describe "SpectateServer Integration" do
         end
 
         expect(spectator.player.entity_id).not_to eq(0_u64)
-        expect(spectator.dimension_for_test.chunks.size).to be > 0
+        expect(spectator.dimension_for_test.chunks.size).to be > 1
       ensure
         spectator.connection?.try(&.disconnect("test done"))
         spectate_server.stop

--- a/spec/integration/spectate_server_spec.cr
+++ b/spec/integration/spectate_server_spec.cr
@@ -51,4 +51,41 @@ Spectator.describe "SpectateServer Integration" do
       end
     end
   end
+
+  it "spectator connecting before chunks load still ends up spectating with chunks" do
+    main_client = client()
+    Rosegold::Client.protocol_version = main_client.protocol_version
+
+    main_client.join_game do |bot_client|
+      spectate_server = Rosegold::SpectateServer.new("127.0.0.1", spectate_port)
+      spectate_server.attach_client(bot_client)
+      spectate_server.start
+      sleep 0.5.seconds # Allow TCP server to fully start accepting connections
+
+      spectator = Rosegold::Client.new(
+        "127.0.0.1", spectate_port,
+        offline: {uuid: "22222222-2222-2222-2222-222222222222", username: "SpectatorBot"}
+      )
+
+      begin
+        spectator.connect
+
+        deadline = Time.instant + 15.seconds
+        until (spectator.player.entity_id != 0_u64 && spectator.dimension_for_test.chunks.size > 0) || Time.instant > deadline
+          sleep 10.milliseconds
+        end
+
+        unless spectator.connected?
+          fail("Spectator disconnected: #{spectator.connection?.try(&.close_reason)}")
+        end
+
+        expect(spectator.player.entity_id).not_to eq(0_u64)
+        expect(spectator.dimension_for_test.chunks.size).to be > 0
+      ensure
+        spectator.connection?.try(&.disconnect("test done"))
+        spectate_server.stop
+        sleep 0.2.seconds
+      end
+    end
+  end
 end

--- a/src/rosegold/spectate/connection.cr
+++ b/src/rosegold/spectate/connection.cr
@@ -215,6 +215,15 @@ class Rosegold::Spectate::Connection
     @spectate_server.client.try &.spawned? || false
   end
 
+  def world_ready?
+    return false unless client_ready?
+    bot = @spectate_server.client
+    return false unless bot
+
+    feet = bot.player.feet
+    bot.dimension.chunks.has_key?({feet.x.to_i >> 4, feet.z.to_i >> 4})
+  end
+
   def self.decode_varint(bytes : Bytes) : UInt32?
     result = 0_u32
     shift = 0

--- a/src/rosegold/spectate/connection.cr
+++ b/src/rosegold/spectate/connection.cr
@@ -221,7 +221,7 @@ class Rosegold::Spectate::Connection
     return false unless bot
 
     feet = bot.player.feet
-    bot.dimension.chunks.has_key?({feet.x.to_i >> 4, feet.z.to_i >> 4})
+    bot.dimension.chunks.has_key?({(feet.x / 16).floor.to_i32, (feet.z / 16).floor.to_i32})
   end
 
   def self.decode_varint(bytes : Bytes) : UInt32?

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -1,12 +1,21 @@
 module Rosegold::Spectate::Lobby
   private def enter_initial_state
-    if client_ready?
+    if world_ready?
       @spectate_state = State::SPECTATING
       send_spectating_packets
     else
       @spectate_state = State::LOBBY
       send_lobby_packets
       start_lobby_monitor
+    end
+  end
+
+  private def lobby_wait_message : String
+    bot = @spectate_server.client
+    if bot.nil? || !bot.connected?
+      "Waiting for bot to connect to server..."
+    else
+      "Bot connected, waiting for world data..."
     end
   end
 
@@ -31,7 +40,7 @@ module Rosegold::Spectate::Lobby
     send_empty_chunk(0, 0)
 
     # System chat message
-    send_packet(Rosegold::Clientbound::SystemChatMessage.new(TextComponent.new("Waiting for bot to connect..."), false))
+    send_packet(Rosegold::Clientbound::SystemChatMessage.new(TextComponent.new(lobby_wait_message), false))
 
     start_keep_alive_sender
   end
@@ -42,7 +51,7 @@ module Rosegold::Spectate::Lobby
         break unless @connected
         break unless @spectate_state.lobby?
 
-        if client_ready?
+        if world_ready?
           transition_to_spectating
           break
         end
@@ -57,7 +66,7 @@ module Rosegold::Spectate::Lobby
   private def transition_to_spectating
     @transition_mutex.synchronize do
       return unless @spectate_state.lobby?
-      return unless client_ready?
+      return unless world_ready?
       return unless bot = @spectate_server.client
 
       Log.info { "Transitioning #{@username} from lobby to spectating" }

--- a/src/rosegold/spectate/monitoring.cr
+++ b/src/rosegold/spectate/monitoring.cr
@@ -3,6 +3,7 @@ struct Rosegold::Spectate::MonitorState
   property last_chunk_x : Int32
   property last_chunk_z : Int32
   property last_dimension_name : String
+  property last_missing_chunk_check : Time::Instant = Time.instant
 
   def initialize(@last_hotbar_selection, @last_chunk_x, @last_chunk_z, @last_dimension_name); end
 end
@@ -33,6 +34,7 @@ module Rosegold::Spectate::Monitoring
         check_dimension_change(monitor, bot)
         check_hotbar_updates(monitor, bot)
         check_chunk_updates(monitor, bot)
+        check_missing_chunks(monitor, bot)
         track_block_breaking_progress(bot)
       end
     rescue e
@@ -101,6 +103,42 @@ module Rosegold::Spectate::Monitoring
       monitor.last_chunk_x = current_x
       monitor.last_chunk_z = current_z
     end
+  end
+
+  MISSING_CHUNK_CHECK_INTERVAL = 1.second
+
+  private def check_missing_chunks(monitor : MonitorState, bot : Rosegold::Client)
+    now = Time.instant
+    return if now - monitor.last_missing_chunk_check < MISSING_CHUNK_CHECK_INTERVAL
+    monitor.last_missing_chunk_check = now
+
+    render_distance = Server::DEFAULT_RENDER_DISTANCE
+    center_x = monitor.last_chunk_x
+    center_z = monitor.last_chunk_z
+
+    missing_chunks = [] of Tuple(Int32, Int32)
+
+    (-render_distance..render_distance).each do |delta_x|
+      (-render_distance..render_distance).each do |delta_z|
+        chunk_pos = {center_x + delta_x, center_z + delta_z}
+        next if @loaded_chunks.includes?(chunk_pos)
+        next unless bot.dimension.chunk_at?(*chunk_pos)
+
+        missing_chunks << chunk_pos
+      end
+    end
+
+    return if missing_chunks.empty?
+
+    send_packet(Rosegold::Clientbound::ChunkBatchStart.new)
+    loaded_count = 0
+    missing_chunks.each do |chunk_x, chunk_z|
+      if send_chunk_data(chunk_x, chunk_z)
+        @loaded_chunks.add({chunk_x, chunk_z})
+        loaded_count += 1
+      end
+    end
+    send_packet(Rosegold::Clientbound::ChunkBatchFinished.new(loaded_count.to_i32))
   end
 
   private def track_block_breaking_progress(bot : Rosegold::Client)


### PR DESCRIPTION
A vanilla client connecting to the spectate server too early got stuck on "Loading terrain...". Vanilla only dismisses that screen after Game Event 13 and a meshed chunk at the synced player position, and survival mode (unlike spectator) requires that chunk. Our lobby gate, `client_ready?`, only checked that the bot's physics and inventory were up, not that its chunk had actually landed in `bot.dimension`. So a spectator could get pushed into SPECTATING with zero chunks sent, and nothing ever retried.

Changes:
- Added `Connection#world_ready?`, which is `client_ready?` plus a check that the bot's current chunk is loaded. The lobby now waits on this instead of `client_ready?`, so early spectators sit in LOBBY until the world is actually there.
- Added a chunk backfill pass to the monitoring loop (throttled to ~once a second) that catches chunks which loaded into the bot's dimension after the spectator was already transitioned, since the only prior trigger was the bot crossing a chunk border.
- Split the lobby wait message depending on whether the bot client is connected yet or just waiting on world data.
- Added an integration spec that connects a spectator right after `join_game` and confirms it still ends up spectating with chunks (didn't run it here since docker-based integration tests conflict with other parallel runs).