### PR TITLE
Add spectator UI broadcast API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Open that URL, enter the code, and sign in with the Microsoft account that owns 
 
 All the examples start a [SpectateServer](https://rosegoldmc.github.io/rosegold.cr/Rosegold/SpectateServer.html) on `localhost:25566`. Open Minecraft, add a server with that address, and connect to see through your bot's eyes in real time — its position, inventory, health, and everything happening around it. No auth required.
 
+Scripts can also push UI straight to everyone spectating: chat lines, an action bar, and a boss bar for progress.
+
+```crystal
+spectate.chat "hello"
+spectate.action_bar "mining 42%"
+spectate.boss_bar "Progress", 42, 100
+```
+
 ### 5. Choosing Minecraft Versions
 
 By default Rosegold supports every Minecraft version it knows about and auto-detects which one the server speaks. Pick a mode by what you `require`:

--- a/spec/packets/clientbound/boss_event_spec.cr
+++ b/spec/packets/clientbound/boss_event_spec.cr
@@ -1,0 +1,120 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::BossEvent do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "uses correct packet ID per protocol" do
+    expect(Rosegold::Clientbound::BossEvent[772_u32]).to eq(0x09_u32)
+    expect(Rosegold::Clientbound::BossEvent[774_u32]).to eq(0x09_u32)
+    expect(Rosegold::Clientbound::BossEvent[775_u32]).to eq(0x09_u32)
+  end
+
+  describe "add action" do
+    it "round-trips title, health, color, division, flags" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.add(
+        uuid,
+        Rosegold::TextComponent.new("Progress"),
+        0.42_f32,
+        Rosegold::Clientbound::BossEvent::Color::Green,
+        Rosegold::Clientbound::BossEvent::Division::Notches10,
+        0x01_u8
+      )
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte # packet id
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.uuid).to eq(uuid)
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+      expect(read_packet.title.try(&.to_s)).to eq("Progress")
+      expect(read_packet.health).to be_close(0.42, 1e-6)
+      expect(read_packet.color).to eq(Rosegold::Clientbound::BossEvent::Color::Green)
+      expect(read_packet.division).to eq(Rosegold::Clientbound::BossEvent::Division::Notches10)
+      expect(read_packet.flags).to eq(0x01_u8)
+    end
+  end
+
+  describe "remove action" do
+    it "round-trips with no extra fields" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.remove(uuid)
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.uuid).to eq(uuid)
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::Remove)
+    end
+  end
+
+  describe "update health action" do
+    it "round-trips health only" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.update_health(uuid, 0.75_f32)
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::UpdateHealth)
+      expect(read_packet.health).to be_close(0.75, 1e-6)
+    end
+  end
+
+  describe "update title action" do
+    it "round-trips title only" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.update_title(uuid, Rosegold::TextComponent.new("New Title"))
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::UpdateTitle)
+      expect(read_packet.title.try(&.to_s)).to eq("New Title")
+    end
+  end
+
+  describe "update style action" do
+    it "round-trips color and division only" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.update_style(uuid, Rosegold::Clientbound::BossEvent::Color::Purple, Rosegold::Clientbound::BossEvent::Division::Notches20)
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::UpdateStyle)
+      expect(read_packet.color).to eq(Rosegold::Clientbound::BossEvent::Color::Purple)
+      expect(read_packet.division).to eq(Rosegold::Clientbound::BossEvent::Division::Notches20)
+    end
+  end
+
+  describe "update flags action" do
+    it "round-trips flags only" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.update_flags(uuid, 0x06_u8)
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::UpdateFlags)
+      expect(read_packet.flags).to eq(0x06_u8)
+    end
+  end
+end

--- a/spec/packets/clientbound/boss_event_spec.cr
+++ b/spec/packets/clientbound/boss_event_spec.cr
@@ -5,8 +5,10 @@ Spectator.describe Rosegold::Clientbound::BossEvent do
 
   it "uses correct packet ID per protocol" do
     expect(Rosegold::Clientbound::BossEvent[772_u32]).to eq(0x09_u32)
+    expect(Rosegold::Clientbound::BossEvent[773_u32]).to eq(0x09_u32)
     expect(Rosegold::Clientbound::BossEvent[774_u32]).to eq(0x09_u32)
     expect(Rosegold::Clientbound::BossEvent[775_u32]).to eq(0x09_u32)
+    expect(Rosegold::Clientbound::BossEvent[776_u32]).to eq(0x09_u32)
   end
 
   describe "add action" do

--- a/spec/packets/clientbound/set_action_bar_text_spec.cr
+++ b/spec/packets/clientbound/set_action_bar_text_spec.cr
@@ -1,0 +1,33 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::SetActionBarText do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "uses correct packet ID per protocol" do
+    expect(Rosegold::Clientbound::SetActionBarText[772_u32]).to eq(0x50_u32)
+    expect(Rosegold::Clientbound::SetActionBarText[774_u32]).to eq(0x55_u32)
+    expect(Rosegold::Clientbound::SetActionBarText[775_u32]).to eq(0x57_u32)
+  end
+
+  it "round-trips a simple text message" do
+    Rosegold::Client.protocol_version = 774_u32
+
+    packet = Rosegold::Clientbound::SetActionBarText.new(Rosegold::TextComponent.new("mining 42%"))
+    bytes = packet.write
+
+    io = Minecraft::IO::Memory.new(bytes)
+    io.read_byte # packet id
+    read_packet = Rosegold::Clientbound::SetActionBarText.read(io)
+
+    expect(read_packet.text.to_s).to eq("mining 42%")
+  end
+
+  it "writes the correct packet id byte for the active protocol" do
+    Rosegold::Client.protocol_version = 774_u32
+
+    packet = Rosegold::Clientbound::SetActionBarText.new(Rosegold::TextComponent.new("hi"))
+    bytes = packet.write
+
+    expect(bytes[0]).to eq(0x55_u8)
+  end
+end

--- a/spec/packets/clientbound/set_action_bar_text_spec.cr
+++ b/spec/packets/clientbound/set_action_bar_text_spec.cr
@@ -5,8 +5,10 @@ Spectator.describe Rosegold::Clientbound::SetActionBarText do
 
   it "uses correct packet ID per protocol" do
     expect(Rosegold::Clientbound::SetActionBarText[772_u32]).to eq(0x50_u32)
+    expect(Rosegold::Clientbound::SetActionBarText[773_u32]).to eq(0x55_u32)
     expect(Rosegold::Clientbound::SetActionBarText[774_u32]).to eq(0x55_u32)
     expect(Rosegold::Clientbound::SetActionBarText[775_u32]).to eq(0x57_u32)
+    expect(Rosegold::Clientbound::SetActionBarText[776_u32]).to eq(0x57_u32)
   end
 
   it "round-trips a simple text message" do

--- a/src/rosegold/packets/clientbound/boss_event.cr
+++ b/src/rosegold/packets/clientbound/boss_event.cr
@@ -1,0 +1,136 @@
+require "../../models/text_component"
+require "../packet"
+
+class Rosegold::Clientbound::BossEvent < Rosegold::Clientbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+
+  packet_ids({
+    772_u32 => 0x09_u32, # MC 1.21.8
+    774_u32 => 0x09_u32, # MC 1.21.11
+    775_u32 => 0x09_u32, # MC 26.1
+  })
+
+  enum Action : UInt32
+    Add          = 0
+    Remove       = 1
+    UpdateHealth = 2
+    UpdateTitle  = 3
+    UpdateStyle  = 4
+    UpdateFlags  = 5
+  end
+
+  enum Color : UInt32
+    Pink   = 0
+    Blue   = 1
+    Red    = 2
+    Green  = 3
+    Yellow = 4
+    Purple = 5
+    White  = 6
+  end
+
+  enum Division : UInt32
+    None      = 0
+    Notches6  = 1
+    Notches10 = 2
+    Notches12 = 3
+    Notches20 = 4
+  end
+
+  property uuid : UUID
+  property action : Action
+  property title : Rosegold::TextComponent?
+  property health : Float32?
+  property color : Color?
+  property division : Division?
+  property flags : UInt8?
+
+  def initialize(@uuid, @action, @title = nil, @health = nil, @color = nil, @division = nil, @flags = nil); end
+
+  def self.add(uuid : UUID, title : Rosegold::TextComponent, health : Float32, color : Color, division : Division, flags : UInt8 = 0_u8)
+    self.new(uuid, Action::Add, title, health, color, division, flags)
+  end
+
+  def self.remove(uuid : UUID)
+    self.new(uuid, Action::Remove)
+  end
+
+  def self.update_health(uuid : UUID, health : Float32)
+    self.new(uuid, Action::UpdateHealth, health: health)
+  end
+
+  def self.update_title(uuid : UUID, title : Rosegold::TextComponent)
+    self.new(uuid, Action::UpdateTitle, title: title)
+  end
+
+  def self.update_style(uuid : UUID, color : Color, division : Division)
+    self.new(uuid, Action::UpdateStyle, color: color, division: division)
+  end
+
+  def self.update_flags(uuid : UUID, flags : UInt8)
+    self.new(uuid, Action::UpdateFlags, flags: flags)
+  end
+
+  def self.read(packet)
+    uuid = packet.read_uuid
+    action = Action.from_value(packet.read_var_int)
+
+    case action
+    in .add?
+      title = packet.read_text_component
+      health = packet.read_float
+      color = Color.from_value(packet.read_var_int)
+      division = Division.from_value(packet.read_var_int)
+      flags = packet.read_byte
+      self.new(uuid, action, title, health, color, division, flags)
+    in .remove?
+      self.new(uuid, action)
+    in .update_health?
+      self.new(uuid, action, health: packet.read_float)
+    in .update_title?
+      self.new(uuid, action, title: packet.read_text_component)
+    in .update_style?
+      color = Color.from_value(packet.read_var_int)
+      division = Division.from_value(packet.read_var_int)
+      self.new(uuid, action, color: color, division: division)
+    in .update_flags?
+      self.new(uuid, action, flags: packet.read_byte)
+    end
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      buffer.write uuid
+      buffer.write action.value
+
+      case action
+      in .add?
+        raise "BossEvent add requires title, health, color, division, flags" unless (t = title) && (h = health) && (c = color) && (d = division) && (f = flags)
+        t.write(buffer)
+        buffer.write h
+        buffer.write c.value
+        buffer.write d.value
+        buffer.write f
+      in .remove?
+      in .update_health?
+        raise "BossEvent update_health requires health" unless h = health
+        buffer.write h
+      in .update_title?
+        raise "BossEvent update_title requires title" unless t = title
+        t.write(buffer)
+      in .update_style?
+        raise "BossEvent update_style requires color, division" unless (c = color) && (d = division)
+        buffer.write c.value
+        buffer.write d.value
+      in .update_flags?
+        raise "BossEvent update_flags requires flags" unless f = flags
+        buffer.write f
+      end
+    end.to_slice
+  end
+
+  def callback(client)
+    Log.debug { "[BOSS EVENT] #{action} #{uuid}" }
+  end
+end

--- a/src/rosegold/packets/clientbound/boss_event.cr
+++ b/src/rosegold/packets/clientbound/boss_event.cr
@@ -7,7 +7,9 @@ class Rosegold::Clientbound::BossEvent < Rosegold::Clientbound::Packet
   packet_ids({
     772_u32 => 0x09_u32, # MC 1.21.8
     774_u32 => 0x09_u32, # MC 1.21.11
+    773_u32 => 0x09_u32, # MC 1.21.9
     775_u32 => 0x09_u32, # MC 26.1
+    776_u32 => 0x09_u32, # MC 26.2
   })
 
   enum Action : UInt32

--- a/src/rosegold/packets/clientbound/set_action_bar_text.cr
+++ b/src/rosegold/packets/clientbound/set_action_bar_text.cr
@@ -7,7 +7,9 @@ class Rosegold::Clientbound::SetActionBarText < Rosegold::Clientbound::Packet
   packet_ids({
     772_u32 => 0x50_u32, # MC 1.21.8
     774_u32 => 0x55_u32, # MC 1.21.11
+    773_u32 => 0x55_u32, # MC 1.21.9
     775_u32 => 0x57_u32, # MC 26.1
+    776_u32 => 0x57_u32, # MC 26.2
   })
 
   property text : Rosegold::TextComponent

--- a/src/rosegold/packets/clientbound/set_action_bar_text.cr
+++ b/src/rosegold/packets/clientbound/set_action_bar_text.cr
@@ -1,0 +1,31 @@
+require "../../models/text_component"
+require "../packet"
+
+class Rosegold::Clientbound::SetActionBarText < Rosegold::Clientbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+
+  packet_ids({
+    772_u32 => 0x50_u32, # MC 1.21.8
+    774_u32 => 0x55_u32, # MC 1.21.11
+    775_u32 => 0x57_u32, # MC 26.1
+  })
+
+  property text : Rosegold::TextComponent
+
+  def initialize(@text); end
+
+  def self.read(packet)
+    self.new(packet.read_text_component)
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      text.write(buffer)
+    end.to_slice
+  end
+
+  def callback(client)
+    Log.debug { "[ACTION BAR] " + text.to_s }
+  end
+end

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -105,6 +105,7 @@ module Rosegold::Spectate::Lobby
       setup_arm_swing_listener
       setup_container_closed_listener
       setup_raw_packet_relay
+      @spectate_server.replay_ui_state(self)
 
       Log.info { "#{@username} is now spectating" }
     end

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -23,6 +23,7 @@ module Rosegold::Spectate::PlaySession
     setup_command_suggestions_listener
     setup_raw_packet_relay
     send_cached_commands
+    @spectate_server.replay_ui_state(self)
     start_keep_alive_sender
   end
 

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -280,6 +280,9 @@ class Rosegold::Spectate::Server
     stop_caching_commands
     @cached_commands_bytes = nil
     @client = nil
+    @last_action_bar = nil
+    @boss_bar_active = false
+    @last_boss_bar_title = nil
   end
 
   private def start_caching_commands(client : Rosegold::Client)

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -56,6 +56,7 @@ class Rosegold::Spectate::Server
     "attach_entity"                => {772_u32 => 0x5D_u32, 774_u32 => 0x62_u32, 775_u32 => 0x64_u32},
     "entity_teleport"              => {772_u32 => 0x76_u32, 774_u32 => 0x7B_u32, 775_u32 => 0x7D_u32},
     "commands"                     => {772_u32 => 0x10_u32, 774_u32 => 0x10_u32, 775_u32 => 0x10_u32},
+    "boss_event"                   => {772_u32 => 0x09_u32, 774_u32 => 0x09_u32, 775_u32 => 0x09_u32},
   }.transform_values { |ids| ids.merge({773_u32 => ids[774_u32], 776_u32 => ids[775_u32]}) }
 
   macro build_forwarded_packets_method
@@ -117,11 +118,100 @@ class Rosegold::Spectate::Server
 
   @next_command_suggestion_tid = Atomic(UInt32).new(0_u32)
 
+  @boss_bar_uuid = UUID.random
+  @boss_bar_active = false
+  @last_action_bar : Rosegold::TextComponent? = nil
+  @last_boss_bar_title : Rosegold::TextComponent? = nil
+  @last_boss_bar_progress : Float32 = 0.0_f32
+  @last_boss_bar_color : Clientbound::BossEvent::Color = Clientbound::BossEvent::Color::White
+  @last_boss_bar_division : Clientbound::BossEvent::Division = Clientbound::BossEvent::Division::None
+
   def initialize(@host : String = "127.0.0.1", @port : Int32 = 25566)
   end
 
   def next_command_suggestion_tid : UInt32
     @next_command_suggestion_tid.add(1_u32) &+ 1_u32
+  end
+
+  # Broadcast a chat message to every spectating connection.
+  def chat(message : String | Rosegold::TextComponent)
+    broadcast(Clientbound::SystemChatMessage.new(as_text_component(message), false))
+  end
+
+  # Broadcast an action bar message to every spectating connection.
+  # Sticky: replayed to spectators that join later, until replaced.
+  def action_bar(text : String | Rosegold::TextComponent)
+    component = as_text_component(text)
+    @last_action_bar = component
+    broadcast(Clientbound::SetActionBarText.new(component))
+  end
+
+  # Broadcast a boss bar update to every spectating connection.
+  # The server owns a single boss bar with one stable UUID: the first call
+  # sends an add, later calls send targeted updates.
+  def boss_bar(
+    title : String | Rosegold::TextComponent,
+    progress : Float64,
+    color : Clientbound::BossEvent::Color = Clientbound::BossEvent::Color::White,
+    division : Clientbound::BossEvent::Division = Clientbound::BossEvent::Division::None,
+  )
+    component = as_text_component(title)
+    health = progress.clamp(0.0, 1.0).to_f32
+
+    if @boss_bar_active
+      broadcast(Clientbound::BossEvent.update_title(@boss_bar_uuid, component)) if @last_boss_bar_title.try(&.to_s) != component.to_s
+      broadcast(Clientbound::BossEvent.update_style(@boss_bar_uuid, color, division)) if @last_boss_bar_color != color || @last_boss_bar_division != division
+      broadcast(Clientbound::BossEvent.update_health(@boss_bar_uuid, health))
+    else
+      broadcast(Clientbound::BossEvent.add(@boss_bar_uuid, component, health, color, division))
+      @boss_bar_active = true
+    end
+
+    @last_boss_bar_title = component
+    @last_boss_bar_progress = health
+    @last_boss_bar_color = color
+    @last_boss_bar_division = division
+  end
+
+  # Convenience overload computing progress from current/max, clamped to 0..1.
+  def boss_bar(
+    title : String | Rosegold::TextComponent,
+    current : Number,
+    max : Number,
+    color : Clientbound::BossEvent::Color = Clientbound::BossEvent::Color::White,
+    division : Clientbound::BossEvent::Division = Clientbound::BossEvent::Division::None,
+  )
+    progress = max.to_f64 > 0 ? current.to_f64 / max.to_f64 : 0.0
+    boss_bar(title, progress, color, division)
+  end
+
+  # Remove the boss bar from every spectating connection and clear stored state.
+  def clear_boss_bar
+    return unless @boss_bar_active
+    broadcast(Clientbound::BossEvent.remove(@boss_bar_uuid))
+    @boss_bar_active = false
+    @last_boss_bar_title = nil
+  end
+
+  # Replay stored action bar and boss bar state to a spectator that just joined.
+  def replay_ui_state(connection : Connection)
+    if text = @last_action_bar
+      connection.send_packet(Clientbound::SetActionBarText.new(text))
+    end
+
+    if @boss_bar_active && (title = @last_boss_bar_title)
+      connection.send_packet(Clientbound::BossEvent.add(@boss_bar_uuid, title, @last_boss_bar_progress, @last_boss_bar_color, @last_boss_bar_division))
+    end
+  end
+
+  private def as_text_component(value : String | Rosegold::TextComponent) : Rosegold::TextComponent
+    value.is_a?(String) ? Rosegold::TextComponent.new(value) : value
+  end
+
+  private def broadcast(packet : Clientbound::Packet)
+    @connections.select(&.spectate_state.spectating?).each do |connection|
+      connection.send_packet(packet)
+    end
   end
 
   def start


### PR DESCRIPTION
Scripts driving a bot can now push UI to every connected spectator: chat lines, an action bar, and a boss bar.

```crystal
spectate.chat "hello"
spectate.action_bar "mining 42%"
spectate.boss_bar "Progress", 42, 100
```

Two new write-capable packets to back it, `Clientbound::SetActionBarText` and `Clientbound::BossEvent` (add/remove/update health/update title/update style/update flags, matching the vanilla protocol). Both have unit specs covering write/read round trips.

The server owns one boss bar with a stable random UUID and picks the narrowest update action for each call (health, title, or style) instead of resending the whole bar. Action bar and boss bar state are sticky: last value gets replayed to spectators who join later, wired into both `send_spectating_packets` and the lobby-to-spectating transition.

Also added `boss_event` to `UNIMPLEMENTED_FORWARDED` so boss bars from the real server the bot is connected to still raw-forward to spectators, distinct from the one the server owns.

## Test plan
- [x] `crystal build --no-codegen src/rosegold.cr`
- [x] `crystal tool format`
- [x] `bin/ameba` on touched files
- [x] `crystal spec spec/packets spec/models spec/minecraft spec/inventory` (420 examples, 0 failures)
- [ ] Manual check with a real Minecraft client against the spectate server