### PR TITLE
Tidy spectate lobby entry and fiber lifecycles

### DIFF
--- a/src/rosegold/spectate/connection.cr
+++ b/src/rosegold/spectate/connection.cr
@@ -37,6 +37,9 @@ class Rosegold::Spectate::Connection
   property last_dig_progress : Float32 = 0.0_f32
   @handshake_protocol : UInt32 = 0_u32
   @keep_alive_running : Bool = false
+  @inventory_polling_running : Bool = false
+  @bot_monitoring_running : Bool = false
+  @lobby_monitor_running : Bool = false
   @packet_send_mutex = Mutex.new
   @transition_mutex = Mutex.new
 

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -46,6 +46,8 @@ module Rosegold::Spectate::Lobby
   end
 
   private def start_lobby_monitor
+    return if @lobby_monitor_running
+    @lobby_monitor_running = true
     spawn do
       loop do
         break unless @connected
@@ -60,6 +62,8 @@ module Rosegold::Spectate::Lobby
       end
     rescue e
       Log.error { "Lobby monitor error: #{e}" }
+    ensure
+      @lobby_monitor_running = false
     end
   end
 

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -96,24 +96,7 @@ module Rosegold::Spectate::Lobby
       # Unload lobby chunk
       send_packet(Rosegold::Clientbound::UnloadChunk.new(0, 0))
 
-      send_player_abilities
-      send_default_spawn_position(bot)
-      send_player_position(bot)
-      send_set_time(bot)
-      send_update_health(bot)
-      send_set_experience(bot)
-      start_inventory_polling
-      send_hotbar_selection(bot.player.hotbar_selection)
-      send_start_waiting_for_chunks
-      send_chunks
-      send_existing_players
-      send_existing_entities
-      send_existing_entity_effects
-      start_bot_monitoring
-      setup_position_event_listener
-      setup_arm_swing_listener
-      setup_container_closed_listener
-      setup_raw_packet_relay
+      start_spectating_session(bot)
 
       Log.info { "#{@username} is now spectating" }
     end

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -118,6 +118,9 @@ module Rosegold::Spectate::Lobby
       unload_all_chunks
       destroy_all_entities
 
+      @last_digging_block = nil
+      @last_dig_progress = 0.0_f32
+
       @client = nil
 
       # Send Respawn to transition to spectator mode (lobby)

--- a/src/rosegold/spectate/monitoring.cr
+++ b/src/rosegold/spectate/monitoring.cr
@@ -10,8 +10,10 @@ end
 
 module Rosegold::Spectate::Monitoring
   private def start_bot_monitoring
+    return if @bot_monitoring_running
     return unless bot = @client
 
+    @bot_monitoring_running = true
     spawn do
       monitor = MonitorState.new(
         last_hotbar_selection: bot.player.hotbar_selection,
@@ -40,6 +42,8 @@ module Rosegold::Spectate::Monitoring
     rescue e
       Log.error { "Bot monitoring error: #{e}" }
       Log.error exception: e
+    ensure
+      @bot_monitoring_running = false
     end
   end
 

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -3,6 +3,10 @@ module Rosegold::Spectate::PlaySession
     return unless bot = @client
 
     send_join_game(bot)
+    start_spectating_session(bot)
+  end
+
+  private def start_spectating_session(bot : Rosegold::Client)
     send_set_time(bot)
     send_default_spawn_position(bot)
     send_player_abilities

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -237,6 +237,8 @@ module Rosegold::Spectate::PlaySession
   end
 
   private def start_inventory_polling
+    return if @inventory_polling_running
+    @inventory_polling_running = true
     spawn do
       loop do
         send_inventory_content
@@ -248,6 +250,8 @@ module Rosegold::Spectate::PlaySession
       end
     rescue ex
       Log.debug { "Inventory polling error: #{ex}" }
+    ensure
+      @inventory_polling_running = false
     end
   end
 end


### PR DESCRIPTION
Light correctness pass on the spectate module. Stacked on #345, so this targets `spectate-loading-terrain` and retargets to main once that merges.

The lobby-to-spectating path had re-implemented the play-session entry sequence inline and drifted from it. Spectators who arrived through the lobby (bot reconnect) never got `setup_command_suggestions_listener` or the cached Commands packet, so no command tab-completion. Both paths now call a shared `start_spectating_session`, so the lobby path picks up those two calls and the packet order matches the direct path. Only the preamble differs (fresh Login+join vs Respawn+unload-lobby-chunk).

Every spectating entry spawned a new inventory-polling fiber with no running guard. Across repeated lobby to spectating cycles a single connection accumulated concurrent pollers, each sending SetContainerContent every second. `start_bot_monitoring` and the lobby monitor could stack the same way. All three now carry a running flag like the existing keep-alive sender.

The block-breaking tracker (`@last_digging_block` / `@last_dig_progress`) was not reset when returning to the lobby, even though the spectator world is wiped there. A stale position could suppress the next session's crack overlay, so it is now cleared alongside the world unload.

## Noticed, not fixed
- `send_player_position` and `send_lobby_packets` hardcode teleport id `1` while `send_player_position_update` increments `@teleport_id`. Teleport ids are not validated against confirms (called out as accepted), so no behavior impact today.
- `@teleport_id` is not reset across lobby/spectating transitions. It wraps with `&+`, so harmless.
- `wait_for_bot_registries` (configuration.cr) can loop while sending ConfigurationKeepAlive but never processes the client's keep-alive responses in that state; left alone since it is out of the stated scope and I could not confirm a concrete failure by reading.
