### PR TITLE
Spectate server improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Open that URL, enter the code, and sign in with the Microsoft account that owns 
 
 All the examples start a [SpectateServer](https://rosegoldmc.github.io/rosegold.cr/Rosegold/SpectateServer.html) on `localhost:25566`. Open Minecraft, add a server with that address, and connect to see through your bot's eyes in real time — its position, inventory, health, and everything happening around it. No auth required.
 
+Scripts can also push UI straight to everyone spectating: chat lines, an action bar, and a boss bar for progress.
+
+```crystal
+spectate.chat "hello"
+spectate.action_bar "mining 42%"
+spectate.boss_bar "Progress", 42, 100
+```
+
 ### 5. Choosing Minecraft Versions
 
 By default Rosegold supports every Minecraft version it knows about and auto-detects which one the server speaks. Pick a mode by what you `require`:

--- a/spec/integration/spectate_disconnect_spec.cr
+++ b/spec/integration/spectate_disconnect_spec.cr
@@ -1,0 +1,67 @@
+require "../spec_helper"
+
+Spectator.describe "SpectateServer bot disconnect" do
+  let(spectate_port) { 25571 }
+
+  def wait_until(timeout : Time::Span, &) : Bool
+    deadline = Time.instant + timeout
+    until (yield) || Time.instant > deadline
+      sleep 20.milliseconds
+    end
+    Time.instant <= deadline
+  end
+
+  # A spectator connected before the bot drops must survive the transition to lobby,
+  # receive the lobby chat, and stay connected across a reconnect/disconnect flap.
+  it "keeps the spectator connected and in lobby when the bot disconnects" do
+    bot1 = client()
+    bot1.join_game
+    Rosegold::Client.protocol_version = bot1.protocol_version
+
+    spectate_server = Rosegold::SpectateServer.new("127.0.0.1", spectate_port)
+    spectate_server.attach_client(bot1)
+    spectate_server.start
+    sleep 0.5.seconds
+
+    spectator = Rosegold::Client.new(
+      "127.0.0.1", spectate_port,
+      offline: {uuid: "33333333-3333-3333-3333-333333333333", username: "SpectatorBot"}
+    )
+
+    lobby_messages = 0
+    spectator.on(Rosegold::Clientbound::SystemChatMessage) do |e|
+      lobby_messages += 1 if e.message.to_s.includes?("disconnected")
+    end
+
+    current_bot = bot1
+    begin
+      spectator.connect
+      fail("spectator never started spectating") unless wait_until(15.seconds) { spectator.dimension_for_test.chunks.size > 1 }
+
+      admin.chat "/kick #{AdminBot::TEST_PLAYER}"
+      fail("no lobby chat after bot disconnect") unless wait_until(10.seconds) { lobby_messages >= 1 }
+      fail("spectator dropped on bot disconnect: #{spectator.connection?.try(&.close_reason)}") unless spectator.connected?
+
+      bot2 = client()
+      bot2.join_game
+      spectate_server.attach_client(bot2)
+      current_bot = bot2
+      fail("spectator never re-entered spectating") unless wait_until(15.seconds) { spectator.dimension_for_test.chunks.size > 1 }
+
+      admin.chat "/kick #{AdminBot::TEST_PLAYER}"
+      fail("no lobby chat after 2nd disconnect") unless wait_until(10.seconds) { lobby_messages >= 2 }
+
+      # Survive a full keep-alive interval in lobby without the server closing the socket.
+      wait_until(25.seconds) { !spectator.connected? }
+      fail("spectator disconnected in lobby: #{spectator.connection?.try(&.close_reason)}") unless spectator.connected?
+
+      expect(spectator.connected?).to be_true
+      expect(lobby_messages).to be >= 2
+    ensure
+      spectator.connection?.try(&.disconnect("test done"))
+      spectate_server.stop
+      current_bot.connection?.try(&.disconnect("done"))
+      sleep 0.3.seconds
+    end
+  end
+end

--- a/spec/integration/spectate_server_spec.cr
+++ b/spec/integration/spectate_server_spec.cr
@@ -51,4 +51,42 @@ Spectator.describe "SpectateServer Integration" do
       end
     end
   end
+
+  it "spectator connecting before chunks load still ends up spectating with chunks" do
+    main_client = client()
+    Rosegold::Client.protocol_version = main_client.protocol_version
+
+    main_client.join_game do |bot_client|
+      spectate_server = Rosegold::SpectateServer.new("127.0.0.1", spectate_port)
+      spectate_server.attach_client(bot_client)
+      spectate_server.start
+      sleep 0.5.seconds # Allow TCP server to fully start accepting connections
+
+      spectator = Rosegold::Client.new(
+        "127.0.0.1", spectate_port,
+        offline: {uuid: "22222222-2222-2222-2222-222222222222", username: "SpectatorBot"}
+      )
+
+      begin
+        spectator.connect
+
+        # Lobby serves exactly one empty chunk; spectating serves a render-distance square
+        deadline = Time.instant + 15.seconds
+        until (spectator.player.entity_id != 0_u64 && spectator.dimension_for_test.chunks.size > 1) || Time.instant > deadline
+          sleep 10.milliseconds
+        end
+
+        unless spectator.connected?
+          fail("Spectator disconnected: #{spectator.connection?.try(&.close_reason)}")
+        end
+
+        expect(spectator.player.entity_id).not_to eq(0_u64)
+        expect(spectator.dimension_for_test.chunks.size).to be > 1
+      ensure
+        spectator.connection?.try(&.disconnect("test done"))
+        spectate_server.stop
+        sleep 0.2.seconds
+      end
+    end
+  end
 end

--- a/spec/models/sneak_changed_spec.cr
+++ b/spec/models/sneak_changed_spec.cr
@@ -1,0 +1,12 @@
+require "../spec_helper"
+
+Spectator.describe Rosegold::Event::SneakChanged do
+  it "is a subclass of Event" do
+    expect(Rosegold::Event::SneakChanged.new(true)).to be_a Rosegold::Event
+  end
+
+  it "exposes the sneaking flag" do
+    expect(Rosegold::Event::SneakChanged.new(true).sneaking?).to be_true
+    expect(Rosegold::Event::SneakChanged.new(false).sneaking?).to be_false
+  end
+end

--- a/spec/packets/clientbound/boss_event_spec.cr
+++ b/spec/packets/clientbound/boss_event_spec.cr
@@ -1,0 +1,122 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::BossEvent do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "uses correct packet ID per protocol" do
+    expect(Rosegold::Clientbound::BossEvent[772_u32]).to eq(0x09_u32)
+    expect(Rosegold::Clientbound::BossEvent[773_u32]).to eq(0x09_u32)
+    expect(Rosegold::Clientbound::BossEvent[774_u32]).to eq(0x09_u32)
+    expect(Rosegold::Clientbound::BossEvent[775_u32]).to eq(0x09_u32)
+    expect(Rosegold::Clientbound::BossEvent[776_u32]).to eq(0x09_u32)
+  end
+
+  describe "add action" do
+    it "round-trips title, health, color, division, flags" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.add(
+        uuid,
+        Rosegold::TextComponent.new("Progress"),
+        0.42_f32,
+        Rosegold::Clientbound::BossEvent::Color::Green,
+        Rosegold::Clientbound::BossEvent::Division::Notches10,
+        0x01_u8
+      )
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte # packet id
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.uuid).to eq(uuid)
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+      expect(read_packet.title.try(&.to_s)).to eq("Progress")
+      expect(read_packet.health).to be_close(0.42, 1e-6)
+      expect(read_packet.color).to eq(Rosegold::Clientbound::BossEvent::Color::Green)
+      expect(read_packet.division).to eq(Rosegold::Clientbound::BossEvent::Division::Notches10)
+      expect(read_packet.flags).to eq(0x01_u8)
+    end
+  end
+
+  describe "remove action" do
+    it "round-trips with no extra fields" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.remove(uuid)
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.uuid).to eq(uuid)
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::Remove)
+    end
+  end
+
+  describe "update health action" do
+    it "round-trips health only" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.update_health(uuid, 0.75_f32)
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::UpdateHealth)
+      expect(read_packet.health).to be_close(0.75, 1e-6)
+    end
+  end
+
+  describe "update title action" do
+    it "round-trips title only" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.update_title(uuid, Rosegold::TextComponent.new("New Title"))
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::UpdateTitle)
+      expect(read_packet.title.try(&.to_s)).to eq("New Title")
+    end
+  end
+
+  describe "update style action" do
+    it "round-trips color and division only" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.update_style(uuid, Rosegold::Clientbound::BossEvent::Color::Purple, Rosegold::Clientbound::BossEvent::Division::Notches20)
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::UpdateStyle)
+      expect(read_packet.color).to eq(Rosegold::Clientbound::BossEvent::Color::Purple)
+      expect(read_packet.division).to eq(Rosegold::Clientbound::BossEvent::Division::Notches20)
+    end
+  end
+
+  describe "update flags action" do
+    it "round-trips flags only" do
+      Rosegold::Client.protocol_version = 774_u32
+      uuid = UUID.random
+
+      packet = Rosegold::Clientbound::BossEvent.update_flags(uuid, 0x06_u8)
+
+      io = Minecraft::IO::Memory.new(packet.write)
+      io.read_byte
+      read_packet = Rosegold::Clientbound::BossEvent.read(io)
+
+      expect(read_packet.action).to eq(Rosegold::Clientbound::BossEvent::Action::UpdateFlags)
+      expect(read_packet.flags).to eq(0x06_u8)
+    end
+  end
+end

--- a/spec/packets/clientbound/player_rotation_serialization_spec.cr
+++ b/spec/packets/clientbound/player_rotation_serialization_spec.cr
@@ -1,0 +1,37 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::PlayerRotation do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "round-trips yaw, pitch and relative flags for protocol 774" do
+    Rosegold::Client.protocol_version = 774_u32
+
+    packet = Rosegold::Clientbound::PlayerRotation.new(45.0_f32, -12.5_f32, true, false)
+    bytes = packet.write
+
+    expect(bytes[0]).to eq(0x47_u8)
+
+    io = Minecraft::IO::Memory.new(bytes[1..])
+    parsed = Rosegold::Clientbound::PlayerRotation.read(io)
+
+    expect(parsed.yaw).to be_close(45.0_f32, 1e-4)
+    expect(parsed.pitch).to be_close(-12.5_f32, 1e-4)
+    expect(parsed.relative_yaw?).to be_true
+    expect(parsed.relative_pitch?).to be_false
+  end
+
+  it "round-trips yaw and pitch for protocol 772" do
+    Rosegold::Client.protocol_version = 772_u32
+
+    packet = Rosegold::Clientbound::PlayerRotation.new(90.0_f32, 30.0_f32)
+    bytes = packet.write
+
+    expect(bytes[0]).to eq(0x42_u8)
+
+    io = Minecraft::IO::Memory.new(bytes[1..])
+    parsed = Rosegold::Clientbound::PlayerRotation.read(io)
+
+    expect(parsed.yaw).to be_close(90.0_f32, 1e-4)
+    expect(parsed.pitch).to be_close(30.0_f32, 1e-4)
+  end
+end

--- a/spec/packets/clientbound/set_action_bar_text_spec.cr
+++ b/spec/packets/clientbound/set_action_bar_text_spec.cr
@@ -1,0 +1,35 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::SetActionBarText do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "uses correct packet ID per protocol" do
+    expect(Rosegold::Clientbound::SetActionBarText[772_u32]).to eq(0x50_u32)
+    expect(Rosegold::Clientbound::SetActionBarText[773_u32]).to eq(0x55_u32)
+    expect(Rosegold::Clientbound::SetActionBarText[774_u32]).to eq(0x55_u32)
+    expect(Rosegold::Clientbound::SetActionBarText[775_u32]).to eq(0x57_u32)
+    expect(Rosegold::Clientbound::SetActionBarText[776_u32]).to eq(0x57_u32)
+  end
+
+  it "round-trips a simple text message" do
+    Rosegold::Client.protocol_version = 774_u32
+
+    packet = Rosegold::Clientbound::SetActionBarText.new(Rosegold::TextComponent.new("mining 42%"))
+    bytes = packet.write
+
+    io = Minecraft::IO::Memory.new(bytes)
+    io.read_byte # packet id
+    read_packet = Rosegold::Clientbound::SetActionBarText.read(io)
+
+    expect(read_packet.text.to_s).to eq("mining 42%")
+  end
+
+  it "writes the correct packet id byte for the active protocol" do
+    Rosegold::Client.protocol_version = 774_u32
+
+    packet = Rosegold::Clientbound::SetActionBarText.new(Rosegold::TextComponent.new("hi"))
+    bytes = packet.write
+
+    expect(bytes[0]).to eq(0x55_u8)
+  end
+end

--- a/spec/packets/clientbound/set_passengers_serialization_spec.cr
+++ b/spec/packets/clientbound/set_passengers_serialization_spec.cr
@@ -1,0 +1,30 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::SetPassengers do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "round-trips entity id and passengers for protocol 774" do
+    Rosegold::Client.protocol_version = 774_u32
+
+    packet = Rosegold::Clientbound::SetPassengers.new(0x7ffffffe_u32, [0x7fffffff_u32])
+    bytes = packet.write
+
+    expect(bytes[0]).to eq(0x69_u8)
+
+    io = Minecraft::IO::Memory.new(bytes[1..])
+    parsed = Rosegold::Clientbound::SetPassengers.read(io)
+
+    expect(parsed.entity_id).to eq(0x7ffffffe_u32)
+    expect(parsed.passengers).to eq([0x7fffffff_u32])
+  end
+
+  it "writes an empty passenger list" do
+    Rosegold::Client.protocol_version = 774_u32
+
+    packet = Rosegold::Clientbound::SetPassengers.new(0x7ffffffe_u32, [] of UInt32)
+    io = Minecraft::IO::Memory.new(packet.write[1..])
+    parsed = Rosegold::Clientbound::SetPassengers.read(io)
+
+    expect(parsed.passengers).to be_empty
+  end
+end

--- a/src/rosegold/client.cr
+++ b/src/rosegold/client.cr
@@ -300,7 +300,9 @@ class Rosegold::Client < Rosegold::EventEmitter
 
     detect_protocol_version
 
-    io = Minecraft::IO::Wrap.new TCPSocket.new(host, port)
+    socket = TCPSocket.new(host, port)
+    socket.tcp_nodelay = true
+    io = Minecraft::IO::Wrap.new socket
     connection = @connection = Connection::Client.new io, ProtocolState::HANDSHAKING, protocol_version, self
     @current_protocol_state = ProtocolState::HANDSHAKING
     connection.handler.try &.on Event::Disconnected do |_event|
@@ -410,7 +412,9 @@ class Rosegold::Client < Rosegold::EventEmitter
   end
 
   def self.status(host : String, port : UInt16 = 25565)
-    io = Minecraft::IO::Wrap.new TCPSocket.new(host, port)
+    socket = TCPSocket.new(host, port)
+    socket.tcp_nodelay = true
+    io = Minecraft::IO::Wrap.new socket
     connection = Connection::Client.new io, ProtocolState::HANDSHAKING, Client.protocol_version
 
     connection.send_packet Serverbound::Handshake.new Client.protocol_version, host, port, 1

--- a/src/rosegold/control/physics.cr
+++ b/src/rosegold/control/physics.cr
@@ -208,6 +208,7 @@ class Rosegold::Physics
     sprint false if sneaking
 
     player.sneaking = sneaking
+    client.emit_event Event::SneakChanged.new(sneaking)
     # Sneaking is handled via PlayerInput Sneak flag (bit 0x20)
   end
 

--- a/src/rosegold/events/sneak_changed.cr
+++ b/src/rosegold/events/sneak_changed.cr
@@ -1,0 +1,7 @@
+require "./event"
+
+class Rosegold::Event::SneakChanged < Rosegold::Event
+  getter? sneaking : Bool
+
+  def initialize(@sneaking : Bool); end
+end

--- a/src/rosegold/packets/clientbound/boss_event.cr
+++ b/src/rosegold/packets/clientbound/boss_event.cr
@@ -1,0 +1,138 @@
+require "../../models/text_component"
+require "../packet"
+
+class Rosegold::Clientbound::BossEvent < Rosegold::Clientbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+
+  packet_ids({
+    772_u32 => 0x09_u32, # MC 1.21.8
+    774_u32 => 0x09_u32, # MC 1.21.11
+    773_u32 => 0x09_u32, # MC 1.21.9
+    775_u32 => 0x09_u32, # MC 26.1
+    776_u32 => 0x09_u32, # MC 26.2
+  })
+
+  enum Action : UInt32
+    Add          = 0
+    Remove       = 1
+    UpdateHealth = 2
+    UpdateTitle  = 3
+    UpdateStyle  = 4
+    UpdateFlags  = 5
+  end
+
+  enum Color : UInt32
+    Pink   = 0
+    Blue   = 1
+    Red    = 2
+    Green  = 3
+    Yellow = 4
+    Purple = 5
+    White  = 6
+  end
+
+  enum Division : UInt32
+    None      = 0
+    Notches6  = 1
+    Notches10 = 2
+    Notches12 = 3
+    Notches20 = 4
+  end
+
+  property uuid : UUID
+  property action : Action
+  property title : Rosegold::TextComponent?
+  property health : Float32?
+  property color : Color?
+  property division : Division?
+  property flags : UInt8?
+
+  def initialize(@uuid, @action, @title = nil, @health = nil, @color = nil, @division = nil, @flags = nil); end
+
+  def self.add(uuid : UUID, title : Rosegold::TextComponent, health : Float32, color : Color, division : Division, flags : UInt8 = 0_u8)
+    self.new(uuid, Action::Add, title, health, color, division, flags)
+  end
+
+  def self.remove(uuid : UUID)
+    self.new(uuid, Action::Remove)
+  end
+
+  def self.update_health(uuid : UUID, health : Float32)
+    self.new(uuid, Action::UpdateHealth, health: health)
+  end
+
+  def self.update_title(uuid : UUID, title : Rosegold::TextComponent)
+    self.new(uuid, Action::UpdateTitle, title: title)
+  end
+
+  def self.update_style(uuid : UUID, color : Color, division : Division)
+    self.new(uuid, Action::UpdateStyle, color: color, division: division)
+  end
+
+  def self.update_flags(uuid : UUID, flags : UInt8)
+    self.new(uuid, Action::UpdateFlags, flags: flags)
+  end
+
+  def self.read(packet)
+    uuid = packet.read_uuid
+    action = Action.from_value(packet.read_var_int)
+
+    case action
+    in .add?
+      title = packet.read_text_component
+      health = packet.read_float
+      color = Color.from_value(packet.read_var_int)
+      division = Division.from_value(packet.read_var_int)
+      flags = packet.read_byte
+      self.new(uuid, action, title, health, color, division, flags)
+    in .remove?
+      self.new(uuid, action)
+    in .update_health?
+      self.new(uuid, action, health: packet.read_float)
+    in .update_title?
+      self.new(uuid, action, title: packet.read_text_component)
+    in .update_style?
+      color = Color.from_value(packet.read_var_int)
+      division = Division.from_value(packet.read_var_int)
+      self.new(uuid, action, color: color, division: division)
+    in .update_flags?
+      self.new(uuid, action, flags: packet.read_byte)
+    end
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      buffer.write uuid
+      buffer.write action.value
+
+      case action
+      in .add?
+        raise "BossEvent add requires title, health, color, division, flags" unless (t = title) && (h = health) && (c = color) && (d = division) && (f = flags)
+        t.write(buffer)
+        buffer.write h
+        buffer.write c.value
+        buffer.write d.value
+        buffer.write f
+      in .remove?
+      in .update_health?
+        raise "BossEvent update_health requires health" unless h = health
+        buffer.write h
+      in .update_title?
+        raise "BossEvent update_title requires title" unless t = title
+        t.write(buffer)
+      in .update_style?
+        raise "BossEvent update_style requires color, division" unless (c = color) && (d = division)
+        buffer.write c.value
+        buffer.write d.value
+      in .update_flags?
+        raise "BossEvent update_flags requires flags" unless f = flags
+        buffer.write f
+      end
+    end.to_slice
+  end
+
+  def callback(client)
+    Log.debug { "[BOSS EVENT] #{action} #{uuid}" }
+  end
+end

--- a/src/rosegold/packets/clientbound/player_rotation.cr
+++ b/src/rosegold/packets/clientbound/player_rotation.cr
@@ -42,9 +42,9 @@ class Rosegold::Clientbound::PlayerRotation < Rosegold::Clientbound::Packet
       io.write self.class.packet_id_for_protocol(Client.protocol_version)
       if Client.protocol_version >= 773_u32
         io.write yaw
-        io.write relative_yaw
+        io.write relative_yaw?
         io.write pitch
-        io.write relative_pitch
+        io.write relative_pitch?
       else
         io.write yaw
         io.write pitch

--- a/src/rosegold/packets/clientbound/set_action_bar_text.cr
+++ b/src/rosegold/packets/clientbound/set_action_bar_text.cr
@@ -1,0 +1,33 @@
+require "../../models/text_component"
+require "../packet"
+
+class Rosegold::Clientbound::SetActionBarText < Rosegold::Clientbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+
+  packet_ids({
+    772_u32 => 0x50_u32, # MC 1.21.8
+    774_u32 => 0x55_u32, # MC 1.21.11
+    773_u32 => 0x55_u32, # MC 1.21.9
+    775_u32 => 0x57_u32, # MC 26.1
+    776_u32 => 0x57_u32, # MC 26.2
+  })
+
+  property text : Rosegold::TextComponent
+
+  def initialize(@text); end
+
+  def self.read(packet)
+    self.new(packet.read_text_component)
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      text.write(buffer)
+    end.to_slice
+  end
+
+  def callback(client)
+    Log.debug { "[ACTION BAR] " + text.to_s }
+  end
+end

--- a/src/rosegold/packets/clientbound/set_passengers.cr
+++ b/src/rosegold/packets/clientbound/set_passengers.cr
@@ -27,7 +27,7 @@ class Rosegold::Clientbound::SetPassengers < Rosegold::Clientbound::Packet
     Minecraft::IO::Memory.new.tap do |buffer|
       buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
       buffer.write entity_id
-      buffer.write_var_int(passengers.length)
+      buffer.write(passengers.size)
       passengers.each do |eid|
         buffer.write eid
       end

--- a/src/rosegold/spectate/connection.cr
+++ b/src/rosegold/spectate/connection.cr
@@ -37,6 +37,9 @@ class Rosegold::Spectate::Connection
   property last_dig_progress : Float32 = 0.0_f32
   @handshake_protocol : UInt32 = 0_u32
   @keep_alive_running : Bool = false
+  @inventory_polling_running : Bool = false
+  @bot_monitoring_running : Bool = false
+  @lobby_monitor_running : Bool = false
   @packet_send_mutex = Mutex.new
   @transition_mutex = Mutex.new
 

--- a/src/rosegold/spectate/connection.cr
+++ b/src/rosegold/spectate/connection.cr
@@ -4,6 +4,7 @@ require "./world_sync"
 require "./play_session"
 require "./monitoring"
 require "./packet_relay"
+require "./look_smoothing"
 require "./lobby"
 
 enum Rosegold::Spectate::State
@@ -18,6 +19,7 @@ class Rosegold::Spectate::Connection
   include Spectate::PlaySession
   include Spectate::Monitoring
   include Spectate::PacketRelay
+  include Spectate::LookSmoothing
   include Spectate::Lobby
 
   Log = ::Log.for self
@@ -40,6 +42,10 @@ class Rosegold::Spectate::Connection
   @inventory_polling_running : Bool = false
   @bot_monitoring_running : Bool = false
   @lobby_monitor_running : Bool = false
+  @look_sender_running : Bool = false
+  @prev_look : Look? = nil
+  @last_look : Look? = nil
+  @last_look_time : Time::Instant = Time.instant
   @packet_send_mutex = Mutex.new
   @transition_mutex = Mutex.new
 

--- a/src/rosegold/spectate/connection.cr
+++ b/src/rosegold/spectate/connection.cr
@@ -5,6 +5,7 @@ require "./play_session"
 require "./monitoring"
 require "./packet_relay"
 require "./look_smoothing"
+require "./sneak_camera"
 require "./lobby"
 
 enum Rosegold::Spectate::State
@@ -20,6 +21,7 @@ class Rosegold::Spectate::Connection
   include Spectate::Monitoring
   include Spectate::PacketRelay
   include Spectate::LookSmoothing
+  include Spectate::SneakCamera
   include Spectate::Lobby
 
   Log = ::Log.for self

--- a/src/rosegold/spectate/connection.cr
+++ b/src/rosegold/spectate/connection.cr
@@ -215,6 +215,15 @@ class Rosegold::Spectate::Connection
     @spectate_server.client.try &.spawned? || false
   end
 
+  def world_ready?
+    return false unless client_ready?
+    bot = @spectate_server.client
+    return false unless bot
+
+    feet = bot.player.feet
+    bot.dimension.chunks.has_key?({(feet.x / 16).floor.to_i32, (feet.z / 16).floor.to_i32})
+  end
+
   def self.decode_varint(bytes : Bytes) : UInt32?
     result = 0_u32
     shift = 0

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -112,6 +112,10 @@ module Rosegold::Spectate::Lobby
 
       Log.info { "Transitioning #{@username} from spectating to lobby" }
 
+      # Must precede any lobby packet: the look/inventory sender fibers gate on
+      # spectating? and would otherwise emit stale packets after the Respawn.
+      @spectate_state = State::LOBBY
+
       cleanup_event_handlers
 
       # Unload all world state
@@ -140,8 +144,6 @@ module Rosegold::Spectate::Lobby
         data_kept: 0_u8
       )
       send_packet(respawn)
-
-      @spectate_state = State::LOBBY
 
       spawn_pos = Vec3i.new(0, 100, 0)
       send_packet(Rosegold::Clientbound::SetDefaultSpawnPosition.new(spawn_pos, 0.0_f32, "minecraft:overworld"))

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -46,6 +46,8 @@ module Rosegold::Spectate::Lobby
   end
 
   private def start_lobby_monitor
+    return if @lobby_monitor_running
+    @lobby_monitor_running = true
     spawn do
       loop do
         break unless @connected
@@ -60,6 +62,8 @@ module Rosegold::Spectate::Lobby
       end
     rescue e
       Log.error { "Lobby monitor error: #{e}" }
+    ensure
+      @lobby_monitor_running = false
     end
   end
 

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -1,12 +1,21 @@
 module Rosegold::Spectate::Lobby
   private def enter_initial_state
-    if client_ready?
+    if world_ready?
       @spectate_state = State::SPECTATING
       send_spectating_packets
     else
       @spectate_state = State::LOBBY
       send_lobby_packets
       start_lobby_monitor
+    end
+  end
+
+  private def lobby_wait_message : String
+    bot = @spectate_server.client
+    if bot.nil? || !bot.connected?
+      "Waiting for bot to connect to server..."
+    else
+      "Bot connected, waiting for world data..."
     end
   end
 
@@ -31,7 +40,7 @@ module Rosegold::Spectate::Lobby
     send_empty_chunk(0, 0)
 
     # System chat message
-    send_packet(Rosegold::Clientbound::SystemChatMessage.new(TextComponent.new("Waiting for bot to connect..."), false))
+    send_packet(Rosegold::Clientbound::SystemChatMessage.new(TextComponent.new(lobby_wait_message), false))
 
     start_keep_alive_sender
   end
@@ -42,7 +51,7 @@ module Rosegold::Spectate::Lobby
         break unless @connected
         break unless @spectate_state.lobby?
 
-        if client_ready?
+        if world_ready?
           transition_to_spectating
           break
         end
@@ -57,7 +66,7 @@ module Rosegold::Spectate::Lobby
   private def transition_to_spectating
     @transition_mutex.synchronize do
       return unless @spectate_state.lobby?
-      return unless client_ready?
+      return unless world_ready?
       return unless bot = @spectate_server.client
 
       Log.info { "Transitioning #{@username} from lobby to spectating" }

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -96,24 +96,7 @@ module Rosegold::Spectate::Lobby
       # Unload lobby chunk
       send_packet(Rosegold::Clientbound::UnloadChunk.new(0, 0))
 
-      send_player_abilities
-      send_default_spawn_position(bot)
-      send_player_position(bot)
-      send_set_time(bot)
-      send_update_health(bot)
-      send_set_experience(bot)
-      start_inventory_polling
-      send_hotbar_selection(bot.player.hotbar_selection)
-      send_start_waiting_for_chunks
-      send_chunks
-      send_existing_players
-      send_existing_entities
-      send_existing_entity_effects
-      start_bot_monitoring
-      setup_position_event_listener
-      setup_arm_swing_listener
-      setup_container_closed_listener
-      setup_raw_packet_relay
+      start_spectating_session(bot)
 
       Log.info { "#{@username} is now spectating" }
     end

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -118,6 +118,9 @@ module Rosegold::Spectate::Lobby
       unload_all_chunks
       destroy_all_entities
 
+      @last_digging_block = nil
+      @last_dig_progress = 0.0_f32
+
       @client = nil
 
       # Send Respawn to transition to spectator mode (lobby)

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -118,6 +118,9 @@ module Rosegold::Spectate::Lobby
 
       cleanup_event_handlers
 
+      # The player entity persists across Respawn, so undo any sneak scale.
+      send_spectator_scale(1.0)
+
       # Unload all world state
       unload_all_chunks
       destroy_all_entities

--- a/src/rosegold/spectate/look_smoothing.cr
+++ b/src/rosegold/spectate/look_smoothing.cr
@@ -1,0 +1,63 @@
+module Rosegold::Spectate::LookSmoothing
+  LOOK_TICK_DURATION = 50.milliseconds
+  # SynchronizePlayerPosition relative flags: yaw 0x08, pitch 0x10.
+  RELATIVE_ROTATION_FLAGS = 0x18
+
+  private def reset_look_samples(look : Look)
+    @prev_look = look
+    @last_look = look
+    @last_look_time = Time.instant
+  end
+
+  private def record_look_sample(look : Look)
+    @prev_look = @last_look || look
+    @last_look = look
+    @last_look_time = Time.instant
+  end
+
+  private def start_look_sender
+    return unless Server::LOOK_UPSAMPLING
+    return if @look_sender_running
+    @look_sender_running = true
+    spawn do
+      loop do
+        break unless @connected
+        break unless @spectate_state.spectating?
+        send_interpolated_look
+        sleep Server::LOOK_UPDATE_INTERVAL
+      end
+    rescue ex : IO::Error
+      Log.debug { "Look sender connection closed: #{ex}" }
+    rescue ex
+      Log.error { "Look sender error: #{ex}" }
+    ensure
+      @look_sender_running = false
+    end
+  end
+
+  private def send_interpolated_look
+    last = @last_look
+    return unless last
+    prev = @prev_look
+
+    look = if prev
+             elapsed = (Time.instant - @last_look_time).total_milliseconds
+             fraction = (elapsed / LOOK_TICK_DURATION.total_milliseconds).clamp(0.0, 1.0)
+             interpolate_look(prev, last, fraction)
+           else
+             last
+           end
+
+    send_packet(Rosegold::Clientbound::PlayerRotation.new(look.yaw, look.pitch, false, false))
+  end
+
+  private def interpolate_look(from : Look, to : Look, fraction : Float64) : Look
+    yaw = from.yaw + shortest_angle_delta(from.yaw, to.yaw) * fraction
+    pitch = from.pitch + (to.pitch - from.pitch) * fraction
+    Look.new(yaw.to_f32, pitch.to_f32)
+  end
+
+  private def shortest_angle_delta(from : Float32, to : Float32) : Float64
+    ((to.to_f64 - from.to_f64 + 180.0) % 360.0) - 180.0
+  end
+end

--- a/src/rosegold/spectate/monitoring.cr
+++ b/src/rosegold/spectate/monitoring.cr
@@ -10,8 +10,10 @@ end
 
 module Rosegold::Spectate::Monitoring
   private def start_bot_monitoring
+    return if @bot_monitoring_running
     return unless bot = @client
 
+    @bot_monitoring_running = true
     spawn do
       monitor = MonitorState.new(
         last_hotbar_selection: bot.player.hotbar_selection,
@@ -40,6 +42,8 @@ module Rosegold::Spectate::Monitoring
     rescue e
       Log.error { "Bot monitoring error: #{e}" }
       Log.error exception: e
+    ensure
+      @bot_monitoring_running = false
     end
   end
 

--- a/src/rosegold/spectate/monitoring.cr
+++ b/src/rosegold/spectate/monitoring.cr
@@ -88,6 +88,7 @@ module Rosegold::Spectate::Monitoring
     send_update_health(bot)
     send_set_experience(bot)
     send_inventory_content
+    send_current_sneak_scale(bot)
   end
 
   private def check_hotbar_updates(monitor : MonitorState, bot : Rosegold::Client)

--- a/src/rosegold/spectate/monitoring.cr
+++ b/src/rosegold/spectate/monitoring.cr
@@ -3,6 +3,7 @@ struct Rosegold::Spectate::MonitorState
   property last_chunk_x : Int32
   property last_chunk_z : Int32
   property last_dimension_name : String
+  property last_missing_chunk_check : Time::Instant = Time.instant
 
   def initialize(@last_hotbar_selection, @last_chunk_x, @last_chunk_z, @last_dimension_name); end
 end
@@ -33,6 +34,7 @@ module Rosegold::Spectate::Monitoring
         check_dimension_change(monitor, bot)
         check_hotbar_updates(monitor, bot)
         check_chunk_updates(monitor, bot)
+        check_missing_chunks(monitor, bot)
         track_block_breaking_progress(bot)
       end
     rescue e
@@ -101,6 +103,42 @@ module Rosegold::Spectate::Monitoring
       monitor.last_chunk_x = current_x
       monitor.last_chunk_z = current_z
     end
+  end
+
+  MISSING_CHUNK_CHECK_INTERVAL = 1.second
+
+  private def check_missing_chunks(monitor : MonitorState, bot : Rosegold::Client)
+    now = Time.instant
+    return if now - monitor.last_missing_chunk_check < MISSING_CHUNK_CHECK_INTERVAL
+    monitor.last_missing_chunk_check = now
+
+    render_distance = Server::DEFAULT_RENDER_DISTANCE
+    center_x = monitor.last_chunk_x
+    center_z = monitor.last_chunk_z
+
+    missing_chunks = [] of Tuple(Int32, Int32)
+
+    (-render_distance..render_distance).each do |delta_x|
+      (-render_distance..render_distance).each do |delta_z|
+        chunk_pos = {center_x + delta_x, center_z + delta_z}
+        next if @loaded_chunks.includes?(chunk_pos)
+        next unless bot.dimension.chunk_at?(*chunk_pos)
+
+        missing_chunks << chunk_pos
+      end
+    end
+
+    return if missing_chunks.empty?
+
+    send_packet(Rosegold::Clientbound::ChunkBatchStart.new)
+    loaded_count = 0
+    missing_chunks.each do |chunk_x, chunk_z|
+      if send_chunk_data(chunk_x, chunk_z)
+        @loaded_chunks.add({chunk_x, chunk_z})
+        loaded_count += 1
+      end
+    end
+    send_packet(Rosegold::Clientbound::ChunkBatchFinished.new(loaded_count.to_i32))
   end
 
   private def track_block_breaking_progress(bot : Rosegold::Client)

--- a/src/rosegold/spectate/packet_relay.cr
+++ b/src/rosegold/spectate/packet_relay.cr
@@ -59,6 +59,7 @@ module Rosegold::Spectate::PacketRelay
       next unless @connected
       next unless @spectate_state.spectating?
 
+      record_look_sample(event.look)
       send_player_position_update(
         event.position.x,
         event.position.y,

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -3,6 +3,10 @@ module Rosegold::Spectate::PlaySession
     return unless bot = @client
 
     send_join_game(bot)
+    start_spectating_session(bot)
+  end
+
+  private def start_spectating_session(bot : Rosegold::Client)
     send_set_time(bot)
     send_default_spawn_position(bot)
     send_player_abilities

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -237,6 +237,8 @@ module Rosegold::Spectate::PlaySession
   end
 
   private def start_inventory_polling
+    return if @inventory_polling_running
+    @inventory_polling_running = true
     spawn do
       loop do
         send_inventory_content
@@ -248,6 +250,8 @@ module Rosegold::Spectate::PlaySession
       end
     rescue ex
       Log.debug { "Inventory polling error: #{ex}" }
+    ensure
+      @inventory_polling_running = false
     end
   end
 end

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -26,6 +26,8 @@ module Rosegold::Spectate::PlaySession
     setup_container_closed_listener
     setup_command_suggestions_listener
     setup_raw_packet_relay
+    setup_sneak_listener
+    send_current_sneak_scale(bot)
     reset_look_samples(bot.player.look)
     start_look_sender
     send_cached_commands

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -26,6 +26,8 @@ module Rosegold::Spectate::PlaySession
     setup_container_closed_listener
     setup_command_suggestions_listener
     setup_raw_packet_relay
+    reset_look_samples(bot.player.look)
+    start_look_sender
     send_cached_commands
     start_keep_alive_sender
   end
@@ -228,11 +230,20 @@ module Rosegold::Spectate::PlaySession
   end
 
   private def send_player_position_update(x : Float64, y : Float64, z : Float64, yaw : Float32, pitch : Float32)
-    packet = Rosegold::Clientbound::SynchronizePlayerPosition.new(
-      x, y, z, yaw, pitch,
-      0x00_u8,
-      @teleport_id &+= 1
-    )
+    # With upsampling the look sender owns rotation; relative zero deltas keep this teleport from snapping it back.
+    packet = if Server::LOOK_UPSAMPLING
+               Rosegold::Clientbound::SynchronizePlayerPosition.new(
+                 x, y, z, 0.0_f32, 0.0_f32,
+                 LookSmoothing::RELATIVE_ROTATION_FLAGS,
+                 @teleport_id &+= 1
+               )
+             else
+               Rosegold::Clientbound::SynchronizePlayerPosition.new(
+                 x, y, z, yaw, pitch,
+                 0x00_u8,
+                 @teleport_id &+= 1
+               )
+             end
     send_packet(packet)
   end
 

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -31,6 +31,7 @@ module Rosegold::Spectate::PlaySession
     reset_look_samples(bot.player.look)
     start_look_sender
     send_cached_commands
+    @spectate_server.replay_ui_state(self)
     start_keep_alive_sender
   end
 

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -142,6 +142,7 @@ class Rosegold::Spectate::Server
           end
 
           enable_tcp_keepalive(client_socket)
+          enable_tcp_nodelay(client_socket)
 
           Log.info { "New spectator connection from #{client_socket.remote_address}" }
 
@@ -177,6 +178,12 @@ class Rosegold::Spectate::Server
     socket.tcp_keepalive_count = 3
   rescue ex
     Log.debug { "Failed to enable TCP keepalive: #{ex}" }
+  end
+
+  private def enable_tcp_nodelay(socket : TCPSocket)
+    socket.tcp_nodelay = true
+  rescue ex
+    Log.debug { "Failed to enable TCP nodelay: #{ex}" }
   end
 
   def attach_client(client : Rosegold::Client)

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -10,9 +10,11 @@ class Rosegold::Client; end
 
 class Rosegold::Spectate::Server
   DEFAULT_SPECTATOR_ENTITY_ID = 0x7fffffff
-  DEFAULT_RENDER_DISTANCE     =          4
-  DEFAULT_VIEW_DISTANCE       =     10_u32
-  DEFAULT_SIMULATION_DISTANCE =      3_u32
+  LOOK_UPDATE_INTERVAL        = 16.milliseconds
+  LOOK_UPSAMPLING             = true
+  DEFAULT_RENDER_DISTANCE     =      4
+  DEFAULT_VIEW_DISTANCE       = 10_u32
+  DEFAULT_SIMULATION_DISTANCE =  3_u32
   KEEP_ALIVE_INTERVAL         = 20.seconds
   INVENTORY_POLL_INTERVAL     = 1.second
   BOT_MONITOR_INTERVAL        = 50.milliseconds

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -58,6 +58,7 @@ class Rosegold::Spectate::Server
     "attach_entity"                => {772_u32 => 0x5D_u32, 774_u32 => 0x62_u32, 775_u32 => 0x64_u32},
     "entity_teleport"              => {772_u32 => 0x76_u32, 774_u32 => 0x7B_u32, 775_u32 => 0x7D_u32},
     "commands"                     => {772_u32 => 0x10_u32, 774_u32 => 0x10_u32, 775_u32 => 0x10_u32},
+    "boss_event"                   => {772_u32 => 0x09_u32, 774_u32 => 0x09_u32, 775_u32 => 0x09_u32},
   }.transform_values { |ids| ids.merge({773_u32 => ids[774_u32], 776_u32 => ids[775_u32]}) }
 
   macro build_forwarded_packets_method
@@ -119,11 +120,100 @@ class Rosegold::Spectate::Server
 
   @next_command_suggestion_tid = Atomic(UInt32).new(0_u32)
 
+  @boss_bar_uuid = UUID.random
+  @boss_bar_active = false
+  @last_action_bar : Rosegold::TextComponent? = nil
+  @last_boss_bar_title : Rosegold::TextComponent? = nil
+  @last_boss_bar_progress : Float32 = 0.0_f32
+  @last_boss_bar_color : Clientbound::BossEvent::Color = Clientbound::BossEvent::Color::White
+  @last_boss_bar_division : Clientbound::BossEvent::Division = Clientbound::BossEvent::Division::None
+
   def initialize(@host : String = "127.0.0.1", @port : Int32 = 25566)
   end
 
   def next_command_suggestion_tid : UInt32
     @next_command_suggestion_tid.add(1_u32) &+ 1_u32
+  end
+
+  # Broadcast a chat message to every spectating connection.
+  def chat(message : String | Rosegold::TextComponent)
+    broadcast(Clientbound::SystemChatMessage.new(as_text_component(message), false))
+  end
+
+  # Broadcast an action bar message to every spectating connection.
+  # Sticky: replayed to spectators that join later, until replaced.
+  def action_bar(text : String | Rosegold::TextComponent)
+    component = as_text_component(text)
+    @last_action_bar = component
+    broadcast(Clientbound::SetActionBarText.new(component))
+  end
+
+  # Broadcast a boss bar update to every spectating connection.
+  # The server owns a single boss bar with one stable UUID: the first call
+  # sends an add, later calls send targeted updates.
+  def boss_bar(
+    title : String | Rosegold::TextComponent,
+    progress : Float64,
+    color : Clientbound::BossEvent::Color = Clientbound::BossEvent::Color::White,
+    division : Clientbound::BossEvent::Division = Clientbound::BossEvent::Division::None,
+  )
+    component = as_text_component(title)
+    health = progress.clamp(0.0, 1.0).to_f32
+
+    if @boss_bar_active
+      broadcast(Clientbound::BossEvent.update_title(@boss_bar_uuid, component)) if @last_boss_bar_title.try(&.to_s) != component.to_s
+      broadcast(Clientbound::BossEvent.update_style(@boss_bar_uuid, color, division)) if @last_boss_bar_color != color || @last_boss_bar_division != division
+      broadcast(Clientbound::BossEvent.update_health(@boss_bar_uuid, health))
+    else
+      broadcast(Clientbound::BossEvent.add(@boss_bar_uuid, component, health, color, division))
+      @boss_bar_active = true
+    end
+
+    @last_boss_bar_title = component
+    @last_boss_bar_progress = health
+    @last_boss_bar_color = color
+    @last_boss_bar_division = division
+  end
+
+  # Convenience overload computing progress from current/max, clamped to 0..1.
+  def boss_bar(
+    title : String | Rosegold::TextComponent,
+    current : Number,
+    max : Number,
+    color : Clientbound::BossEvent::Color = Clientbound::BossEvent::Color::White,
+    division : Clientbound::BossEvent::Division = Clientbound::BossEvent::Division::None,
+  )
+    progress = max.to_f64 > 0 ? current.to_f64 / max.to_f64 : 0.0
+    boss_bar(title, progress, color, division)
+  end
+
+  # Remove the boss bar from every spectating connection and clear stored state.
+  def clear_boss_bar
+    return unless @boss_bar_active
+    broadcast(Clientbound::BossEvent.remove(@boss_bar_uuid))
+    @boss_bar_active = false
+    @last_boss_bar_title = nil
+  end
+
+  # Replay stored action bar and boss bar state to a spectator that just joined.
+  def replay_ui_state(connection : Connection)
+    if text = @last_action_bar
+      connection.send_packet(Clientbound::SetActionBarText.new(text))
+    end
+
+    if @boss_bar_active && (title = @last_boss_bar_title)
+      connection.send_packet(Clientbound::BossEvent.add(@boss_bar_uuid, title, @last_boss_bar_progress, @last_boss_bar_color, @last_boss_bar_division))
+    end
+  end
+
+  private def as_text_component(value : String | Rosegold::TextComponent) : Rosegold::TextComponent
+    value.is_a?(String) ? Rosegold::TextComponent.new(value) : value
+  end
+
+  private def broadcast(packet : Clientbound::Packet)
+    @connections.select(&.spectate_state.spectating?).each do |connection|
+      connection.send_packet(packet)
+    end
   end
 
   def start
@@ -199,6 +289,9 @@ class Rosegold::Spectate::Server
     stop_caching_commands
     @cached_commands_bytes = nil
     @client = nil
+    @last_action_bar = nil
+    @boss_bar_active = false
+    @last_boss_bar_title = nil
   end
 
   private def start_caching_commands(client : Rosegold::Client)

--- a/src/rosegold/spectate/sneak_camera.cr
+++ b/src/rosegold/spectate/sneak_camera.cr
@@ -1,0 +1,43 @@
+module Rosegold::Spectate::SneakCamera
+  # Client eye height is 1.62 * scale, so this lands the camera at the bot's 1.27 sneaking eye.
+  SNEAK_EYE_SCALE = 1.27 / 1.62
+
+  # minecraft:scale registry index per protocol, from Attributes.java registration order (shifted in 26.2).
+  SCALE_ATTRIBUTE_IDS = {
+    772_u32 => 25_u32,
+    773_u32 => 25_u32,
+    774_u32 => 25_u32,
+    775_u32 => 25_u32,
+    776_u32 => 30_u32,
+  }
+
+  private def setup_sneak_listener
+    track_bot_handler(Rosegold::Event::SneakChanged) do |event|
+      next unless @connected
+      next unless @spectate_state.spectating?
+      send_spectator_scale(event.sneaking? ? SNEAK_EYE_SCALE : 1.0)
+    end
+  end
+
+  private def send_current_sneak_scale(bot : Rosegold::Client)
+    send_spectator_scale(bot.player.sneaking? ? SNEAK_EYE_SCALE : 1.0)
+  end
+
+  private def send_spectator_scale(scale : Float64)
+    pkt_id = Server::UNIMPLEMENTED_FORWARDED["update_attributes"][protocol_version]?
+    attribute_id = SCALE_ATTRIBUTE_IDS[protocol_version]?
+    unless pkt_id && attribute_id
+      Log.debug { "Sneak camera scale unsupported for protocol #{protocol_version}" }
+      return
+    end
+
+    io = Minecraft::IO::Memory.new
+    io.write pkt_id
+    io.write Server::DEFAULT_SPECTATOR_ENTITY_ID.to_u32
+    io.write 1_u32
+    io.write attribute_id
+    io.write_full scale
+    io.write 0_u32
+    send_packet(Rosegold::Clientbound::RawPacket.new(io.to_slice))
+  end
+end


### PR DESCRIPTION
Grab bag of spectate server fixes and a couple of features, all landing on one branch.

Spectators used to get stuck on "Loading terrain" when they connected before the bot's own chunks arrived, and nothing ever retried. The lobby now gates on the bot's chunk actually being in the dimension, and a once-a-second poll backfills any render-distance chunks that load after someone is already watching.

The connection sockets now disable Nagle, so small position and rotation packets go out immediately instead of sitting in a buffer.

A few correctness fixes came out of an audit of the lobby entry path: the entry packets were being sent twice, the polling fibers could stack on repeated transitions, dig tracking wasn't reset when a spectator dropped back to the lobby, and PlayerRotation and SetPassengers serialized wrong.

Look now updates at 60Hz. Per-tick position teleports carry relative zero rotation so a dedicated fiber owns the view and the camera interpolates rather than snapping once a tick. Sneak mirrors the bot by driving the spectator's scale attribute, so ducking reads on the client.

Scripts can also push UI to everyone spectating: chat lines, a sticky action bar, and a boss bar for progress.

```crystal
spectate.chat "hello"
spectate.action_bar "mining 42%"
spectate.boss_bar "Progress", 42, 100
```

Still want a real-client smoke test on the look smoothing and sneak camera before calling those done.


Also fixes a bot-disconnect bug found while testing: the look and inventory sender fibers kept running through the whole spectating-to-lobby transition (they gate on `spectating?`, which only flipped after the Respawn was sent), so stale packets could land mid dimension-switch and the vanilla client would drop with a protocol error instead of sitting in the lobby. The state now flips before any lobby packet goes out, and a new integration spec covers disconnect, reconnect, and disconnect again.
