### PR TITLE
Skip slim entrypoints under crystal docs

### DIFF
--- a/src/rosegold/1.21.11.cr
+++ b/src/rosegold/1.21.11.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:docs) %}
+
 module Rosegold
   COMPILE_ONLY_VERSION = "1.21.11"
 end

--- a/src/rosegold/1.21.8.cr
+++ b/src/rosegold/1.21.8.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:docs) %}
+
 module Rosegold
   COMPILE_ONLY_VERSION = "1.21.8"
 end

--- a/src/rosegold/1.21.9.cr
+++ b/src/rosegold/1.21.9.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:docs) %}
+
 module Rosegold
   COMPILE_ONLY_VERSION = "1.21.9"
 end

--- a/src/rosegold/26.1.cr
+++ b/src/rosegold/26.1.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:docs) %}
+
 module Rosegold
   COMPILE_ONLY_VERSION = "26.1"
 end

--- a/src/rosegold/26.2.cr
+++ b/src/rosegold/26.2.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:docs) %}
+
 module Rosegold
   COMPILE_ONLY_VERSION = "26.2"
 end


### PR DESCRIPTION
The docs deploy on main broke after #339: `crystal docs` compiles all of `src/` in one program, so each per-version entrypoint tripped its require-order guard and then collided on `COMPILE_ONLY_VERSION`.

Fix: `{% skip_file if flag?(:docs) %}` at the top of the 5 entrypoints. Verified `crystal docs` succeeds, all 5 slim builds still type-check, and the wrong-require-order guard still fails the compile with its message.