### PR TITLE
Prevent spectator boss bar update crashes

### DIFF
--- a/spec/integration/spectate_server_spec.cr
+++ b/spec/integration/spectate_server_spec.cr
@@ -5,9 +5,9 @@ Spectator.describe "SpectateServer Integration" do
 
   it "spectator client can connect and receive play packets" do
     main_client = client()
-    Rosegold::Client.protocol_version = main_client.protocol_version
 
     main_client.join_game do |bot_client|
+      Rosegold::Client.protocol_version = bot_client.protocol_version
       bot = Rosegold::Bot.new(bot_client)
       bot.wait_ticks 20 # Ensure physics, inventory, and all systems are fully initialized
 
@@ -54,9 +54,9 @@ Spectator.describe "SpectateServer Integration" do
 
   it "spectator connecting before chunks load still ends up spectating with chunks" do
     main_client = client()
-    Rosegold::Client.protocol_version = main_client.protocol_version
 
     main_client.join_game do |bot_client|
+      Rosegold::Client.protocol_version = bot_client.protocol_version
       spectate_server = Rosegold::SpectateServer.new("127.0.0.1", spectate_port)
       spectate_server.attach_client(bot_client)
       spectate_server.start
@@ -82,6 +82,65 @@ Spectator.describe "SpectateServer Integration" do
 
         expect(spectator.player.entity_id).not_to eq(0_u64)
         expect(spectator.dimension_for_test.chunks.size).to be > 1
+      ensure
+        spectator.connection?.try(&.disconnect("test done"))
+        spectate_server.stop
+        sleep 0.2.seconds
+      end
+    end
+  end
+
+  it "spectator receives complete boss bar states, then remove" do
+    main_client = client()
+
+    main_client.join_game do |bot_client|
+      Rosegold::Client.protocol_version = bot_client.protocol_version
+      bot = Rosegold::Bot.new(bot_client)
+      bot.wait_ticks 20
+      fail("Bot not fully spawned after wait_ticks 20") unless bot_client.spawned?
+
+      spectate_server = Rosegold::SpectateServer.new("127.0.0.1", spectate_port)
+      spectate_server.attach_client(bot_client)
+      spectate_server.start
+      sleep 0.5.seconds
+
+      spectator = Rosegold::Client.new(
+        "127.0.0.1", spectate_port,
+        offline: {uuid: "33333333-3333-3333-3333-333333333333", username: "SpectatorBot"}
+      )
+
+      begin
+        spectator.connect
+
+        deadline = Time.instant + 5.seconds
+        until spectate_server.connections.any?(&.boss_bar_session_active?) || Time.instant > deadline
+          sleep 10.milliseconds
+        end
+
+        unless spectator.connected?
+          fail("Spectator disconnected: #{spectator.connection?.try(&.close_reason)}")
+        end
+        fail("Spectator boss bar session never started") unless spectate_server.connections.any?(&.boss_bar_session_active?)
+
+        boss_events = [] of Rosegold::Clientbound::BossEvent
+        spectator.on(Rosegold::Clientbound::BossEvent) { |event| boss_events << event }
+
+        spectate_server.boss_bar("first", 0.5)
+        spectate_server.boss_bar("second", 0.7)
+        spectate_server.clear_boss_bar
+
+        deadline = Time.instant + 5.seconds
+        until boss_events.size >= 3 || Time.instant > deadline
+          sleep 10.milliseconds
+        end
+
+        actions = boss_events.map(&.action)
+        expect(actions).to eq([
+          Rosegold::Clientbound::BossEvent::Action::Add,
+          Rosegold::Clientbound::BossEvent::Action::Add,
+          Rosegold::Clientbound::BossEvent::Action::Remove,
+        ])
+        expect(boss_events.map(&.uuid).uniq!.size).to eq(1)
       ensure
         spectator.connection?.try(&.disconnect("test done"))
         spectate_server.stop

--- a/spec/rosegold/spectate_server_spec.cr
+++ b/spec/rosegold/spectate_server_spec.cr
@@ -1,0 +1,319 @@
+require "../spec_helper"
+
+Spectator.describe Rosegold::Spectate::Server do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  def fake_spectator(server, active = true)
+    tcp = TCPServer.new("127.0.0.1", 0)
+    spectator_socket = TCPSocket.new("127.0.0.1", tcp.local_address.port)
+    spectator_socket.read_timeout = 1.second
+    connection = Rosegold::Spectate::Connection.new(tcp.accept, server)
+    connection.spectate_state = Rosegold::Spectate::State::SPECTATING
+    session = active ? connection.begin_boss_bar_session : 0_u64
+    server.connections << connection
+    {connection, spectator_socket, tcp, session}
+  end
+
+  def read_boss_event(socket) : Rosegold::Clientbound::BossEvent
+    io = Minecraft::IO::Wrap.new(socket)
+    size = io.read_var_int
+    bytes = Bytes.new(size)
+    io.read_fully(bytes)
+    packet_io = Minecraft::IO::Memory.new(bytes)
+    packet_io.read_byte
+    Rosegold::Clientbound::BossEvent.read(packet_io)
+  end
+
+  def offline_client : Rosegold::Client
+    Rosegold::Client.new("127.0.0.1", 25565, offline: {uuid: "00000000-0000-0000-0000-000000000000", username: "Bot"})
+  end
+
+  def emit_boss_event(client, event)
+    event.callback(client)
+    client.emit_event(event)
+  end
+
+  it "does not raw-forward boss_event on any protocol" do
+    Rosegold::Client::SUPPORTED_PROTOCOLS.each do |protocol|
+      forwarded = Rosegold::Spectate::Server.forwarded_packets(protocol)
+      expect(forwarded.has_key?(Rosegold::Clientbound::BossEvent[protocol])).to be_false
+    end
+  end
+
+  it "sends complete add state on every boss_bar call" do
+    Rosegold::Client.protocol_version = 774_u32
+    server = Rosegold::Spectate::Server.new
+    connection, socket, tcp, _session = fake_spectator(server)
+
+    server.boss_bar("hello", 0.5)
+    server.boss_bar("hello", 0.7)
+
+    add = read_boss_event(socket)
+    expect(add.action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+    expect(add.title.try(&.to_s)).to eq("hello")
+
+    replacement = read_boss_event(socket)
+    expect(replacement.action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+    expect(replacement.health).to be_close(0.7_f32, 1e-6)
+  ensure
+    connection.try(&.close)
+    socket.try(&.close)
+    tcp.try(&.close)
+  end
+
+  it "replaces a boss bar when only title formatting changes" do
+    Rosegold::Client.protocol_version = 774_u32
+    server = Rosegold::Spectate::Server.new
+    connection, socket, tcp, _session = fake_spectator(server)
+    first = Rosegold::TextComponent.new("hello")
+    second = Rosegold::TextComponent.new("hello")
+    second.color = "red"
+
+    server.boss_bar(first, 0.5)
+    server.boss_bar(second, 0.5)
+
+    expect(read_boss_event(socket).action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+    replacement = read_boss_event(socket)
+    expect(replacement.action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+    expect(replacement.title.try(&.color)).to eq("red")
+  ensure
+    connection.try(&.close)
+    socket.try(&.close)
+    tcp.try(&.close)
+  end
+
+  it "sends only complete state during concurrent boss_bar calls" do
+    Rosegold::Client.protocol_version = 774_u32
+    server = Rosegold::Spectate::Server.new
+    connection, socket, tcp, _session = fake_spectator(server)
+    done = Channel(Nil).new
+
+    100.times do |i|
+      spawn do
+        server.boss_bar("bar #{i}", i / 100.0)
+        done.send(nil)
+      end
+    end
+    100.times { done.receive }
+
+    events = Array(Rosegold::Clientbound::BossEvent).new(100) { read_boss_event(socket) }
+    expect(events.all?(&.action.add?)).to be_true
+    expect(events.map(&.uuid).uniq!.size).to eq(1)
+  ensure
+    connection.try(&.close)
+    socket.try(&.close)
+    tcp.try(&.close)
+  end
+
+  it "does not send boss bars before a spectator session starts" do
+    Rosegold::Client.protocol_version = 774_u32
+    server = Rosegold::Spectate::Server.new
+    connection, socket, tcp, _session = fake_spectator(server, active: false)
+    socket.read_timeout = 0.2.seconds
+
+    server.boss_bar("hello", 0.5)
+
+    expect_raises(IO::TimeoutError) { read_boss_event(socket) }
+  ensure
+    connection.try(&.close)
+    socket.try(&.close)
+    tcp.try(&.close)
+  end
+
+  it "sends latest state before replay" do
+    Rosegold::Client.protocol_version = 774_u32
+    server = Rosegold::Spectate::Server.new
+    server.boss_bar("hello", 0.5)
+    connection, socket, tcp, _session = fake_spectator(server)
+
+    server.boss_bar("hello", 0.7)
+
+    add = read_boss_event(socket)
+    expect(add.action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+    expect(add.health).to be_close(0.7_f32, 1e-6)
+  ensure
+    connection.try(&.close)
+    socket.try(&.close)
+    tcp.try(&.close)
+  end
+
+  describe "upstream boss bars" do
+    it "relays complete state and remove for bars the upstream server added" do
+      Rosegold::Client.protocol_version = 774_u32
+      server = Rosegold::Spectate::Server.new
+      client = offline_client
+      server.attach_client(client)
+      connection, socket, tcp, _session = fake_spectator(server)
+
+      uuid = UUID.random
+      title = Rosegold::TextComponent.new("Wither")
+
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.add(uuid, title, 1.0_f32, Rosegold::Clientbound::BossEvent::Color::Purple, Rosegold::Clientbound::BossEvent::Division::None))
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.update_title(uuid, Rosegold::TextComponent.new("Angry Wither")))
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.update_health(uuid, 0.5_f32))
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.remove(uuid))
+
+      expect(read_boss_event(socket).action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+      title_replacement = read_boss_event(socket)
+      expect(title_replacement.action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+      expect(title_replacement.title.try(&.to_s)).to eq("Angry Wither")
+      health_replacement = read_boss_event(socket)
+      expect(health_replacement.action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+      expect(health_replacement.health).to be_close(0.5_f32, 1e-6)
+      expect(read_boss_event(socket).action).to eq(Rosegold::Clientbound::BossEvent::Action::Remove)
+    ensure
+      connection.try(&.close)
+      socket.try(&.close)
+      tcp.try(&.close)
+    end
+
+    it "drops updates for bars the client never saw an add for" do
+      Rosegold::Client.protocol_version = 774_u32
+      server = Rosegold::Spectate::Server.new
+      client = offline_client
+      server.attach_client(client)
+      connection, socket, tcp, _session = fake_spectator(server)
+      socket.read_timeout = 0.2.seconds
+
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.update_health(UUID.random, 0.5_f32))
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.remove(UUID.random))
+
+      expect_raises(IO::TimeoutError) { read_boss_event(socket) }
+    ensure
+      connection.try(&.close)
+      socket.try(&.close)
+      tcp.try(&.close)
+    end
+
+    it "replays current state when add and updates arrived before attachment" do
+      Rosegold::Client.protocol_version = 774_u32
+      client = offline_client
+      uuid = UUID.random
+
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.add(uuid, Rosegold::TextComponent.new("Wither"), 1.0_f32, Rosegold::Clientbound::BossEvent::Color::Purple, Rosegold::Clientbound::BossEvent::Division::None))
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.update_health(uuid, 0.4_f32))
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.update_title(uuid, Rosegold::TextComponent.new("Angry Wither")))
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.update_style(uuid, Rosegold::Clientbound::BossEvent::Color::Red, Rosegold::Clientbound::BossEvent::Division::Notches10))
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.update_flags(uuid, 0x03_u8))
+
+      server = Rosegold::Spectate::Server.new
+      server.attach_client(client)
+      connection, socket, tcp, session = fake_spectator(server)
+      server.replay_ui_state(connection, session)
+
+      add = read_boss_event(socket)
+      expect(add.action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+      expect(add.uuid).to eq(uuid)
+      expect(add.title.try(&.to_s)).to eq("Angry Wither")
+      expect(add.health).to be_close(0.4_f32, 1e-6)
+      expect(add.color).to eq(Rosegold::Clientbound::BossEvent::Color::Red)
+      expect(add.division).to eq(Rosegold::Clientbound::BossEvent::Division::Notches10)
+      expect(add.flags).to eq(0x03_u8)
+    ensure
+      connection.try(&.close)
+      socket.try(&.close)
+      tcp.try(&.close)
+    end
+
+    it "sends an add when an upstream update arrives before replay" do
+      Rosegold::Client.protocol_version = 774_u32
+      client = offline_client
+      uuid = UUID.random
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.add(uuid, Rosegold::TextComponent.new("Wither"), 1.0_f32, Rosegold::Clientbound::BossEvent::Color::Purple, Rosegold::Clientbound::BossEvent::Division::None))
+
+      server = Rosegold::Spectate::Server.new
+      server.attach_client(client)
+      connection, socket, tcp, _session = fake_spectator(server)
+
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.update_health(uuid, 0.5_f32))
+
+      add = read_boss_event(socket)
+      expect(add.action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+      expect(add.uuid).to eq(uuid)
+      expect(add.health).to be_close(0.5_f32, 1e-6)
+    ensure
+      connection.try(&.close)
+      socket.try(&.close)
+      tcp.try(&.close)
+    end
+
+    it "removes bars from a replaced client" do
+      Rosegold::Client.protocol_version = 774_u32
+      first_client = offline_client
+      uuid = UUID.random
+      emit_boss_event(first_client, Rosegold::Clientbound::BossEvent.add(uuid, Rosegold::TextComponent.new("Old Wither"), 1.0_f32, Rosegold::Clientbound::BossEvent::Color::Purple, Rosegold::Clientbound::BossEvent::Division::None))
+
+      server = Rosegold::Spectate::Server.new
+      server.attach_client(first_client)
+      connection, socket, tcp, session = fake_spectator(server)
+      server.replay_ui_state(connection, session)
+      expect(read_boss_event(socket).action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+
+      server.attach_client(offline_client)
+
+      remove = read_boss_event(socket)
+      expect(remove.action).to eq(Rosegold::Clientbound::BossEvent::Action::Remove)
+      expect(remove.uuid).to eq(uuid)
+    ensure
+      connection.try(&.close)
+      socket.try(&.close)
+      tcp.try(&.close)
+    end
+
+    it "removes cached bars when the client starts configuration" do
+      Rosegold::Client.protocol_version = 774_u32
+      client = offline_client
+      uuid = UUID.random
+      emit_boss_event(client, Rosegold::Clientbound::BossEvent.add(uuid, Rosegold::TextComponent.new("Wither"), 1.0_f32, Rosegold::Clientbound::BossEvent::Color::Purple, Rosegold::Clientbound::BossEvent::Division::None))
+
+      server = Rosegold::Spectate::Server.new
+      server.attach_client(client)
+      connection, socket, tcp, session = fake_spectator(server)
+      server.replay_ui_state(connection, session)
+      expect(read_boss_event(socket).action).to eq(Rosegold::Clientbound::BossEvent::Action::Add)
+
+      client.clear_boss_bars
+      client.emit_event(Rosegold::Clientbound::StartConfiguration.new)
+
+      remove = read_boss_event(socket)
+      expect(remove.action).to eq(Rosegold::Clientbound::BossEvent::Action::Remove)
+      expect(remove.uuid).to eq(uuid)
+    ensure
+      connection.try(&.close)
+      socket.try(&.close)
+      tcp.try(&.close)
+    end
+  end
+
+  it "removes known bars before ending a spectator session" do
+    Rosegold::Client.protocol_version = 774_u32
+    server = Rosegold::Spectate::Server.new
+    connection, socket, tcp, _session = fake_spectator(server)
+
+    server.boss_bar("own", 0.5)
+    add = read_boss_event(socket)
+    connection.spectate_state = Rosegold::Spectate::State::LOBBY
+    connection.end_boss_bar_session
+
+    remove = read_boss_event(socket)
+    expect(remove.action).to eq(Rosegold::Clientbound::BossEvent::Action::Remove)
+    expect(remove.uuid).to eq(add.uuid)
+  ensure
+    connection.try(&.close)
+    socket.try(&.close)
+    tcp.try(&.close)
+  end
+
+  it "unsubscribes from client events when stopped" do
+    client = offline_client
+    before = client.event_handlers[Rosegold::Clientbound::BossEvent]?.try(&.size) || 0
+    server = Rosegold::Spectate::Server.new
+    server.attach_client(client)
+
+    expect(client.event_handlers[Rosegold::Clientbound::BossEvent].size).to eq(before + 1)
+
+    server.stop
+
+    expect(client.event_handlers[Rosegold::Clientbound::BossEvent].size).to eq(before)
+  end
+end

--- a/src/rosegold/client.cr
+++ b/src/rosegold/client.cr
@@ -76,6 +76,9 @@ class Rosegold::Client < Rosegold::EventEmitter
     ticker_done : Channel(Nil) = Channel(Nil).new,
     recipe_registry : RecipeRegistry = RecipeRegistry.new
 
+  @boss_bars = Hash(UUID, BossBarState).new
+  @boss_bars_mutex = Mutex.new
+
   def protocol_version
     Client.protocol_version
   end
@@ -193,8 +196,36 @@ class Rosegold::Client < Rosegold::EventEmitter
   end
 
   def set_protocol_state(protocol_state : ProtocolState)
+    clear_boss_bars if @current_protocol_state == ProtocolState::PLAY && protocol_state == ProtocolState::CONFIGURATION
     @current_protocol_state = protocol_state
     connection.protocol_state = protocol_state
+  end
+
+  def apply_boss_event(event : Clientbound::BossEvent)
+    @boss_bars_mutex.synchronize do
+      case event.action
+      in .add?
+        @boss_bars[event.uuid] = BossBarState.from_add(event)
+      in .remove?
+        @boss_bars.delete(event.uuid)
+      in .update_health?, .update_title?, .update_style?, .update_flags?
+        if state = @boss_bars[event.uuid]?
+          @boss_bars[event.uuid] = state.apply(event)
+        end
+      end
+    end
+  end
+
+  def boss_bar_state(uuid : UUID) : BossBarState?
+    @boss_bars_mutex.synchronize { @boss_bars[uuid]? }
+  end
+
+  def boss_bar_states : Array(BossBarState)
+    @boss_bars_mutex.synchronize { @boss_bars.values }
+  end
+
+  def clear_boss_bars
+    @boss_bars_mutex.synchronize { @boss_bars.clear }
   end
 
   def spawned?
@@ -296,6 +327,8 @@ class Rosegold::Client < Rosegold::EventEmitter
   def connect
     raise NotConnected.new "Already connected" if connected?
 
+    clear_boss_bars
+
     authenticate!
 
     detect_protocol_version
@@ -306,6 +339,7 @@ class Rosegold::Client < Rosegold::EventEmitter
     connection = @connection = Connection::Client.new io, ProtocolState::HANDSHAKING, protocol_version, self
     @current_protocol_state = ProtocolState::HANDSHAKING
     connection.handler.try &.on Event::Disconnected do |_event|
+      clear_boss_bars
       physics.handle_disconnect
     end
     Log.info { "Connected to #{host}:#{port}" }

--- a/src/rosegold/packets/clientbound/boss_event.cr
+++ b/src/rosegold/packets/clientbound/boss_event.cr
@@ -133,6 +133,48 @@ class Rosegold::Clientbound::BossEvent < Rosegold::Clientbound::Packet
   end
 
   def callback(client)
+    client.apply_boss_event(self)
     Log.debug { "[BOSS EVENT] #{action} #{uuid}" }
+  end
+end
+
+struct Rosegold::BossBarState
+  getter uuid : UUID
+  getter title : Rosegold::TextComponent
+  getter health : Float32
+  getter color : Rosegold::Clientbound::BossEvent::Color
+  getter division : Rosegold::Clientbound::BossEvent::Division
+  getter flags : UInt8
+
+  def initialize(@uuid, @title, @health, @color, @division, @flags); end
+
+  def self.from_add(event : Rosegold::Clientbound::BossEvent) : self
+    title = event.title || raise "BossEvent add requires title"
+    health = event.health || raise "BossEvent add requires health"
+    color = event.color || raise "BossEvent add requires color"
+    division = event.division || raise "BossEvent add requires division"
+    flags = event.flags || raise "BossEvent add requires flags"
+    new(event.uuid, title, health, color, division, flags)
+  end
+
+  def apply(event : Rosegold::Clientbound::BossEvent) : self
+    case event.action
+    in .add?
+      self.class.from_add(event)
+    in .remove?
+      self
+    in .update_health?
+      self.class.new(uuid, title, event.health || health, color, division, flags)
+    in .update_title?
+      self.class.new(uuid, event.title || title, health, color, division, flags)
+    in .update_style?
+      self.class.new(uuid, title, health, event.color || color, event.division || division, flags)
+    in .update_flags?
+      self.class.new(uuid, title, health, color, division, event.flags || flags)
+    end
+  end
+
+  def add_packet : Rosegold::Clientbound::BossEvent
+    Rosegold::Clientbound::BossEvent.add(uuid, title, health, color, division, flags)
   end
 end

--- a/src/rosegold/spectate/connection.cr
+++ b/src/rosegold/spectate/connection.cr
@@ -1,4 +1,5 @@
 require "./handshake"
+require "deque"
 require "./configuration"
 require "./world_sync"
 require "./play_session"
@@ -14,6 +15,10 @@ enum Rosegold::Spectate::State
 end
 
 class Rosegold::Spectate::Connection
+  private alias BossBarQueueItem = Rosegold::Clientbound::BossEvent | Channel(Nil)
+
+  BOSS_BAR_QUEUE_LIMIT = 1024
+
   include Spectate::Handshake
   include Spectate::Configuration
   include Spectate::WorldSync
@@ -50,6 +55,14 @@ class Rosegold::Spectate::Connection
   @last_look_time : Time::Instant = Time.instant
   @packet_send_mutex = Mutex.new
   @transition_mutex = Mutex.new
+
+  @boss_bar_queue = Deque(BossBarQueueItem).new
+  @boss_bar_queue_mutex = Mutex.new
+  @boss_bar_writer_running = false
+  @boss_bar_queue_overflowed = false
+  @boss_bar_session = 0_u64
+  @boss_bar_session_active = false
+  @known_boss_bars = Set(UUID).new
 
   @bot_handler_cleanups : Array(->) = [] of ->
 
@@ -165,6 +178,119 @@ class Rosegold::Spectate::Connection
     @socket.close
   rescue
     # Socket already closed
+  end
+
+  def begin_boss_bar_session : UInt64
+    @boss_bar_queue_mutex.synchronize do
+      @boss_bar_session &+= 1
+      @boss_bar_session_active = true
+      @known_boss_bars.clear
+      @boss_bar_session
+    end
+  end
+
+  def boss_bar_session?(session : UInt64) : Bool
+    @boss_bar_queue_mutex.synchronize do
+      @boss_bar_session_active && @boss_bar_session == session && @spectate_state.spectating? && @connected
+    end
+  end
+
+  def boss_bar_session_active? : Bool
+    @boss_bar_queue_mutex.synchronize do
+      @boss_bar_session_active && @spectate_state.spectating? && @connected
+    end
+  end
+
+  def enqueue_boss_bar_add(packet : Rosegold::Clientbound::BossEvent, session : UInt64? = nil, replace : Bool = false)
+    start_writer = @boss_bar_queue_mutex.synchronize do
+      next false unless boss_bar_session_valid_unlocked?(session)
+      next false if !replace && @known_boss_bars.includes?(packet.uuid)
+
+      @known_boss_bars << packet.uuid
+      queue_boss_bar_item_unlocked(packet)
+    end
+    start_boss_bar_writer if start_writer
+  end
+
+  def enqueue_boss_bar_remove(uuid : UUID)
+    start_writer = @boss_bar_queue_mutex.synchronize do
+      next false unless boss_bar_session_valid_unlocked?
+      next false unless @known_boss_bars.delete(uuid)
+
+      queue_boss_bar_item_unlocked(Rosegold::Clientbound::BossEvent.remove(uuid))
+    end
+    start_boss_bar_writer if start_writer
+  end
+
+  def end_boss_bar_session
+    barrier = Channel(Nil).new(1)
+    start_writer = @boss_bar_queue_mutex.synchronize do
+      @boss_bar_session_active = false
+      @boss_bar_session &+= 1
+      should_start = false
+      @known_boss_bars.each do |uuid|
+        start = queue_boss_bar_item_unlocked(Rosegold::Clientbound::BossEvent.remove(uuid))
+        should_start = start || should_start
+      end
+      @known_boss_bars.clear
+      start = queue_boss_bar_item_unlocked(barrier)
+      start || should_start
+    end
+    start_boss_bar_writer if start_writer
+    barrier.receive
+  end
+
+  def detach_from_bot(message : String = "Bot disconnected. Waiting for reconnection...")
+    transition_to_lobby(message) if @spectate_state.spectating?
+  end
+
+  private def boss_bar_session_valid_unlocked?(session : UInt64? = nil) : Bool
+    @boss_bar_session_active &&
+      @spectate_state.spectating? &&
+      @connected &&
+      (session.nil? || @boss_bar_session == session)
+  end
+
+  private def queue_boss_bar_item_unlocked(item : BossBarQueueItem) : Bool
+    if item.is_a?(Rosegold::Clientbound::BossEvent) && (@boss_bar_queue_overflowed || @boss_bar_queue.size >= BOSS_BAR_QUEUE_LIMIT)
+      unless @boss_bar_queue_overflowed
+        @boss_bar_queue_overflowed = true
+        spawn do
+          Log.warn { "Closing spectator with an overflowing boss bar queue" }
+          close
+        end
+      end
+      return false
+    end
+
+    @boss_bar_queue << item
+    return false if @boss_bar_writer_running
+
+    @boss_bar_writer_running = true
+    true
+  end
+
+  private def start_boss_bar_writer
+    spawn do
+      loop do
+        item = @boss_bar_queue_mutex.synchronize do
+          if @boss_bar_queue.empty?
+            @boss_bar_writer_running = false
+            nil
+          else
+            @boss_bar_queue.shift
+          end
+        end
+        break unless item
+
+        case item
+        when Rosegold::Clientbound::BossEvent
+          send_packet(item)
+        when Channel(Nil)
+          item.send(nil)
+        end
+      end
+    end
   end
 
   protected def track_bot_handler(event_type : T.class, &block : T ->) forall T

--- a/src/rosegold/spectate/lobby.cr
+++ b/src/rosegold/spectate/lobby.cr
@@ -96,11 +96,12 @@ module Rosegold::Spectate::Lobby
       send_packet(respawn)
 
       @spectate_state = State::SPECTATING
+      boss_bar_session = begin_boss_bar_session
 
       # Unload lobby chunk
       send_packet(Rosegold::Clientbound::UnloadChunk.new(0, 0))
 
-      start_spectating_session(bot)
+      start_spectating_session(bot, boss_bar_session)
 
       Log.info { "#{@username} is now spectating" }
     end
@@ -115,6 +116,7 @@ module Rosegold::Spectate::Lobby
       # Must precede any lobby packet: the look/inventory sender fibers gate on
       # spectating? and would otherwise emit stale packets after the Respawn.
       @spectate_state = State::LOBBY
+      end_boss_bar_session
 
       cleanup_event_handlers
 

--- a/src/rosegold/spectate/play_session.cr
+++ b/src/rosegold/spectate/play_session.cr
@@ -3,10 +3,11 @@ module Rosegold::Spectate::PlaySession
     return unless bot = @client
 
     send_join_game(bot)
-    start_spectating_session(bot)
+    boss_bar_session = begin_boss_bar_session
+    start_spectating_session(bot, boss_bar_session)
   end
 
-  private def start_spectating_session(bot : Rosegold::Client)
+  private def start_spectating_session(bot : Rosegold::Client, boss_bar_session : UInt64)
     send_set_time(bot)
     send_default_spawn_position(bot)
     send_player_abilities
@@ -31,7 +32,7 @@ module Rosegold::Spectate::PlaySession
     reset_look_samples(bot.player.look)
     start_look_sender
     send_cached_commands
-    @spectate_server.replay_ui_state(self)
+    @spectate_server.replay_ui_state(self, boss_bar_session)
     start_keep_alive_sender
   end
 

--- a/src/rosegold/spectate/server.cr
+++ b/src/rosegold/spectate/server.cr
@@ -58,7 +58,6 @@ class Rosegold::Spectate::Server
     "attach_entity"                => {772_u32 => 0x5D_u32, 774_u32 => 0x62_u32, 775_u32 => 0x64_u32},
     "entity_teleport"              => {772_u32 => 0x76_u32, 774_u32 => 0x7B_u32, 775_u32 => 0x7D_u32},
     "commands"                     => {772_u32 => 0x10_u32, 774_u32 => 0x10_u32, 775_u32 => 0x10_u32},
-    "boss_event"                   => {772_u32 => 0x09_u32, 774_u32 => 0x09_u32, 775_u32 => 0x09_u32},
   }.transform_values { |ids| ids.merge({773_u32 => ids[774_u32], 776_u32 => ids[775_u32]}) }
 
   macro build_forwarded_packets_method
@@ -120,6 +119,7 @@ class Rosegold::Spectate::Server
 
   @next_command_suggestion_tid = Atomic(UInt32).new(0_u32)
 
+  @boss_bar_mutex = Mutex.new
   @boss_bar_uuid = UUID.random
   @boss_bar_active = false
   @last_action_bar : Rosegold::TextComponent? = nil
@@ -127,6 +127,12 @@ class Rosegold::Spectate::Server
   @last_boss_bar_progress : Float32 = 0.0_f32
   @last_boss_bar_color : Clientbound::BossEvent::Color = Clientbound::BossEvent::Color::White
   @last_boss_bar_division : Clientbound::BossEvent::Division = Clientbound::BossEvent::Division::None
+
+  @upstream_boss_bars = Hash(UUID, BossBarState).new
+  @bot_boss_bar_handler_id : UUID? = nil
+  @bot_disconnected_handler_id : UUID? = nil
+  @bot_start_configuration_handler_id : UUID? = nil
+  @client_generation = 0_u64
 
   def initialize(@host : String = "127.0.0.1", @port : Int32 = 25566)
   end
@@ -149,8 +155,8 @@ class Rosegold::Spectate::Server
   end
 
   # Broadcast a boss bar update to every spectating connection.
-  # The server owns a single boss bar with one stable UUID: the first call
-  # sends an add, later calls send targeted updates.
+  # Complete add packets also replace existing bars, avoiding vanilla crashes
+  # if the client lost its prior state before an update.
   def boss_bar(
     title : String | Rosegold::TextComponent,
     progress : Float64,
@@ -160,19 +166,22 @@ class Rosegold::Spectate::Server
     component = as_text_component(title)
     health = progress.clamp(0.0, 1.0).to_f32
 
-    if @boss_bar_active
-      broadcast(Clientbound::BossEvent.update_title(@boss_bar_uuid, component)) if @last_boss_bar_title.try(&.to_s) != component.to_s
-      broadcast(Clientbound::BossEvent.update_style(@boss_bar_uuid, color, division)) if @last_boss_bar_color != color || @last_boss_bar_division != division
-      broadcast(Clientbound::BossEvent.update_health(@boss_bar_uuid, health))
-    else
-      broadcast(Clientbound::BossEvent.add(@boss_bar_uuid, component, health, color, division))
-      @boss_bar_active = true
+    @boss_bar_mutex.synchronize do
+      if @boss_bar_active
+        @last_boss_bar_title = component
+        @last_boss_bar_progress = health
+        @last_boss_bar_color = color
+        @last_boss_bar_division = division
+        broadcast_boss_bar_add(current_boss_bar_add, replace: true)
+      else
+        @boss_bar_active = true
+        @last_boss_bar_title = component
+        @last_boss_bar_progress = health
+        @last_boss_bar_color = color
+        @last_boss_bar_division = division
+        broadcast_boss_bar_add(current_boss_bar_add)
+      end
     end
-
-    @last_boss_bar_title = component
-    @last_boss_bar_progress = health
-    @last_boss_bar_color = color
-    @last_boss_bar_division = division
   end
 
   # Convenience overload computing progress from current/max, clamped to 0..1.
@@ -189,20 +198,32 @@ class Rosegold::Spectate::Server
 
   # Remove the boss bar from every spectating connection and clear stored state.
   def clear_boss_bar
-    return unless @boss_bar_active
-    broadcast(Clientbound::BossEvent.remove(@boss_bar_uuid))
-    @boss_bar_active = false
-    @last_boss_bar_title = nil
+    @boss_bar_mutex.synchronize do
+      return unless @boss_bar_active
+      broadcast_boss_bar_remove(@boss_bar_uuid)
+      @boss_bar_active = false
+      @last_boss_bar_title = nil
+    end
   end
 
   # Replay stored action bar and boss bar state to a spectator that just joined.
-  def replay_ui_state(connection : Connection)
+  def replay_ui_state(connection : Connection, boss_bar_session : UInt64)
+    return unless connection.boss_bar_session?(boss_bar_session)
+
     if text = @last_action_bar
       connection.send_packet(Clientbound::SetActionBarText.new(text))
     end
 
-    if @boss_bar_active && (title = @last_boss_bar_title)
-      connection.send_packet(Clientbound::BossEvent.add(@boss_bar_uuid, title, @last_boss_bar_progress, @last_boss_bar_color, @last_boss_bar_division))
+    @boss_bar_mutex.synchronize do
+      return unless connection.boss_bar_session?(boss_bar_session)
+
+      if @boss_bar_active
+        connection.enqueue_boss_bar_add(current_boss_bar_add, boss_bar_session)
+      end
+
+      @upstream_boss_bars.each_value do |state|
+        connection.enqueue_boss_bar_add(state.add_packet, boss_bar_session)
+      end
     end
   end
 
@@ -216,7 +237,28 @@ class Rosegold::Spectate::Server
     end
   end
 
+  private def current_boss_bar_add : Clientbound::BossEvent
+    title = @last_boss_bar_title || raise "Active boss bar requires title"
+    Clientbound::BossEvent.add(@boss_bar_uuid, title, @last_boss_bar_progress, @last_boss_bar_color, @last_boss_bar_division)
+  end
+
+  private def broadcast_boss_bar_add(packet : Clientbound::BossEvent, replace : Bool = false)
+    @connections.each do |connection|
+      connection.enqueue_boss_bar_add(packet, replace: replace)
+    end
+  end
+
+  private def broadcast_boss_bar_remove(uuid : UUID)
+    @connections.each do |connection|
+      connection.enqueue_boss_bar_remove(uuid)
+    end
+  end
+
   def start
+    if (client = @client) && @bot_boss_bar_handler_id.nil?
+      attach_client(client)
+    end
+
     @server = TCPServer.new(host, port)
     Log.info { "SpectateServer listening on #{host}:#{port}" }
 
@@ -258,6 +300,12 @@ class Rosegold::Spectate::Server
   end
 
   def stop
+    stop_caching_commands
+    stop_tracking_boss_bars
+    @boss_bar_mutex.synchronize do
+      @client_generation &+= 1
+      @upstream_boss_bars.clear
+    end
     @server.try &.close
     @connections.dup.each(&.close)
     @connections.clear
@@ -279,22 +327,127 @@ class Rosegold::Spectate::Server
   end
 
   def attach_client(client : Rosegold::Client)
+    previous_client = @client
     stop_caching_commands
+    stop_tracking_boss_bars
     @cached_commands_bytes = nil
-    @client = client
+
+    generation = @boss_bar_mutex.synchronize do
+      @client_generation &+= 1
+      @upstream_boss_bars.each_key { |uuid| broadcast_boss_bar_remove(uuid) }
+      @upstream_boss_bars.clear
+      @client = client
+      @client_generation
+    end
+
+    if previous_client && !previous_client.same?(client)
+      @connections.dup.each(&.detach_from_bot("Bot changed. Loading new world..."))
+    end
+
     start_caching_commands(client)
+    start_tracking_boss_bars(client, generation)
+    sync_upstream_boss_bars(client, generation)
   end
 
   def detach_client
     stop_caching_commands
+    stop_tracking_boss_bars
     @cached_commands_bytes = nil
     @client = nil
     @last_action_bar = nil
-    @boss_bar_active = false
-    @last_boss_bar_title = nil
+    @boss_bar_mutex.synchronize do
+      @client_generation &+= 1
+      if @boss_bar_active
+        broadcast_boss_bar_remove(@boss_bar_uuid)
+        @boss_bar_active = false
+        @last_boss_bar_title = nil
+      end
+      @upstream_boss_bars.each_key do |uuid|
+        broadcast_boss_bar_remove(uuid)
+      end
+      @upstream_boss_bars.clear
+    end
+    @connections.dup.each(&.detach_from_bot)
+  end
+
+  # Relay the upstream server's boss bars to spectators. Only packets for bars
+  # the spectator has seen an add for may be sent: vanilla crashes on updates
+  # for unknown boss bar UUIDs.
+  private def handle_upstream_boss_event(client : Rosegold::Client, generation : UInt64, event : Clientbound::BossEvent)
+    @boss_bar_mutex.synchronize do
+      return unless @client.same?(client) && @client_generation == generation
+
+      case event.action
+      in .add?
+        if state = client.boss_bar_state(event.uuid)
+          replace = @upstream_boss_bars.has_key?(event.uuid)
+          @upstream_boss_bars[event.uuid] = state
+          broadcast_boss_bar_add(state.add_packet, replace: replace)
+        end
+      in .remove?
+        broadcast_boss_bar_remove(event.uuid) if @upstream_boss_bars.delete(event.uuid)
+      in .update_health?, .update_title?, .update_style?, .update_flags?
+        if state = client.boss_bar_state(event.uuid)
+          @upstream_boss_bars[event.uuid] = state
+          broadcast_boss_bar_add(state.add_packet, replace: true)
+        end
+      end
+    end
+  end
+
+  private def start_tracking_boss_bars(client : Rosegold::Client, generation : UInt64)
+    return if @bot_boss_bar_handler_id
+
+    @bot_boss_bar_handler_id = client.on(Clientbound::BossEvent) do |event|
+      handle_upstream_boss_event(client, generation, event)
+    end
+    @bot_disconnected_handler_id = client.on(Event::Disconnected) do |_event|
+      clear_upstream_boss_bars(client, generation)
+    end
+    @bot_start_configuration_handler_id = client.on(Clientbound::StartConfiguration) do |_event|
+      clear_upstream_boss_bars(client, generation)
+    end
+  end
+
+  private def sync_upstream_boss_bars(client : Rosegold::Client, generation : UInt64)
+    @boss_bar_mutex.synchronize do
+      return unless @client.same?(client) && @client_generation == generation
+
+      @upstream_boss_bars.each_key { |uuid| broadcast_boss_bar_remove(uuid) }
+      @upstream_boss_bars = client.boss_bar_states.to_h { |state| {state.uuid, state} }
+      @upstream_boss_bars.each_value { |state| broadcast_boss_bar_add(state.add_packet) }
+    end
+  end
+
+  private def clear_upstream_boss_bars(client : Rosegold::Client, generation : UInt64)
+    @boss_bar_mutex.synchronize do
+      return unless @client.same?(client) && @client_generation == generation
+
+      @upstream_boss_bars.each_key { |uuid| broadcast_boss_bar_remove(uuid) }
+      @upstream_boss_bars.clear
+    end
+  end
+
+  private def stop_tracking_boss_bars
+    if client = @client
+      if id = @bot_boss_bar_handler_id
+        client.off(Clientbound::BossEvent, id)
+      end
+      if id = @bot_disconnected_handler_id
+        client.off(Event::Disconnected, id)
+      end
+      if id = @bot_start_configuration_handler_id
+        client.off(Clientbound::StartConfiguration, id)
+      end
+    end
+    @bot_boss_bar_handler_id = nil
+    @bot_disconnected_handler_id = nil
+    @bot_start_configuration_handler_id = nil
   end
 
   private def start_caching_commands(client : Rosegold::Client)
+    return if @bot_commands_handler_id
+
     commands_pkt_id = UNIMPLEMENTED_FORWARDED["commands"][client.protocol_version]?
     return unless commands_pkt_id
     commands_id_byte = commands_pkt_id.to_u8


### PR DESCRIPTION
## Summary

- track complete upstream boss bar state instead of raw-forwarding it
- send complete `Add` snapshots for every state change, replacing the same UUID safely
- keep delivery ordered and isolated per spectator with bounded queues
- clean up and replay state across lobby, reconnect, configuration, and client replacement transitions

## Why

Minecraft 1.21.11 crashes when a `boss_event` partial update references a UUID missing from the client's boss bar map. Complete snapshots remove that client-state dependency while preserving custom and upstream boss bars.

## Testing

- `crystal spec spec/rosegold spec/minecraft spec/inventory spec/packets spec/models spec/rosegold_spec.cr spec/bot_spec.cr` (468 examples)
- `crystal spec spec/integration/spectate_server_spec.cr` (3 examples against Docker Minecraft 1.21.11)
- `crystal build --no-codegen src/rosegold.cr`
- `bin/ameba`
- confirmed fixed by the affected Minecraft 1.21.11 client
