### PR TITLE
Normalize outbound yaw values

### DIFF
--- a/spec/models/look_spec.cr
+++ b/spec/models/look_spec.cr
@@ -1,0 +1,26 @@
+require "../spec_helper"
+
+Spectator.describe Rosegold::Look do
+  describe ".wrap_yaw" do
+    it "matches Minecraft yaw wrapping" do
+      {
+        -720.0_f32 => 0.0_f32,
+        -540.0_f32 => -180.0_f32,
+        -197.0_f32 => 163.0_f32,
+        -180.0_f32 => -180.0_f32,
+         180.0_f32 => -180.0_f32,
+         197.0_f32 => -163.0_f32,
+         540.0_f32 => -180.0_f32,
+         720.0_f32 => 0.0_f32,
+      }.each do |yaw, expected|
+        expect(described_class.wrap_yaw(yaw)).to eq(expected)
+      end
+    end
+
+    it "replaces non-finite yaw with zero" do
+      expect(described_class.wrap_yaw(Float32::NAN)).to eq(0.0_f32)
+      expect(described_class.wrap_yaw(Float32::INFINITY)).to eq(0.0_f32)
+      expect(described_class.wrap_yaw(-Float32::INFINITY)).to eq(0.0_f32)
+    end
+  end
+end

--- a/spec/packets/serverbound/yaw_serialization_spec.cr
+++ b/spec/packets/serverbound/yaw_serialization_spec.cr
@@ -1,0 +1,66 @@
+require "../../spec_helper"
+
+Spectator.describe "Serverbound yaw serialization" do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "wraps PlayerLook yaw before serialization" do
+    Rosegold::Client.protocol_version = 776_u32
+    packet = Rosegold::Serverbound::PlayerLook.new(0.0_f32, 40.0_f32, true)
+    packet.yaw = -197.0_f32
+    io = Minecraft::IO::Memory.new(packet.write)
+
+    expect(io.read_var_int).to eq(0x20_u32)
+    expect(io.read_float).to eq(163.0_f32)
+    expect(io.read_float).to eq(40.0_f32)
+  end
+
+  it "wraps PlayerPositionAndLook yaw before serialization" do
+    Rosegold::Client.protocol_version = 776_u32
+    packet = Rosegold::Serverbound::PlayerPositionAndLook.new(
+      Rosegold::Vec3d::ORIGIN,
+      Rosegold::Look.new(0.0_f32, 40.0_f32),
+      true
+    )
+    packet.look = Rosegold::Look.new(-197.0_f32, 40.0_f32)
+    io = Minecraft::IO::Memory.new(packet.write)
+
+    expect(io.read_var_int).to eq(0x1F_u32)
+    io.read_double
+    io.read_double
+    io.read_double
+    expect(io.read_float).to eq(163.0_f32)
+    expect(io.read_float).to eq(40.0_f32)
+  end
+
+  it "wraps UseItem yaw before serialization" do
+    Rosegold::Client.protocol_version = 776_u32
+    packet = Rosegold::Serverbound::UseItem.new(
+      sequence: 42,
+      pitch: 40.0_f32
+    )
+    packet.yaw = -197.0_f32
+    io = Minecraft::IO::Memory.new(packet.write)
+
+    expect(io.read_var_int).to eq(0x43_u32)
+    expect(io.read_var_int).to eq(Rosegold::Hand::MainHand.value)
+    expect(io.read_var_int).to eq(42_u32)
+    expect(io.read_float).to eq(163.0_f32)
+    expect(io.read_float).to eq(40.0_f32)
+  end
+
+  it "uses Minecraft's negative-inclusive boundary" do
+    Rosegold::Client.protocol_version = 776_u32
+
+    expect(Rosegold::Serverbound::PlayerLook.new(180.0_f32, 0.0_f32, true).yaw).to eq(-180.0_f32)
+    expect(
+      Rosegold::Serverbound::PlayerPositionAndLook.new(
+        Rosegold::Vec3d::ORIGIN,
+        Rosegold::Look.new(180.0_f32, 0.0_f32),
+        true
+      ).look.yaw
+    ).to eq(-180.0_f32)
+    expect(
+      Rosegold::Serverbound::UseItem.new(yaw: 180.0_f32).yaw
+    ).to eq(-180.0_f32)
+  end
+end

--- a/src/rosegold/packets/serverbound/player_look.cr
+++ b/src/rosegold/packets/serverbound/player_look.cr
@@ -18,7 +18,7 @@ class Rosegold::Serverbound::PlayerLook < Rosegold::Serverbound::Packet
     pushing_against_wall : Bool = false
 
   def initialize(yaw : Float32, pitch : Float32, @on_ground : Bool, @pushing_against_wall : Bool = false)
-    @yaw = sanitize_angle(yaw)
+    @yaw = Look.wrap_yaw(yaw)
     @pitch = sanitize_angle(pitch)
   end
 
@@ -44,7 +44,7 @@ class Rosegold::Serverbound::PlayerLook < Rosegold::Serverbound::Packet
   def write : Bytes
     Minecraft::IO::Memory.new.tap do |buffer|
       buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
-      buffer.write yaw
+      buffer.write Look.wrap_yaw(yaw)
       buffer.write pitch
 
       # MC 1.21.4+ format: Use bit field (0x01: on ground, 0x02: pushing against wall)

--- a/src/rosegold/packets/serverbound/player_position_and_look.cr
+++ b/src/rosegold/packets/serverbound/player_position_and_look.cr
@@ -29,7 +29,7 @@ class Rosegold::Serverbound::PlayerPositionAndLook < Rosegold::Serverbound::Pack
 
     # Validate and sanitize look angles
     @look = Look.new(
-      sanitize_angle(look.yaw),
+      Look.wrap_yaw(look.yaw),
       sanitize_angle(look.pitch)
     )
   end
@@ -59,7 +59,7 @@ class Rosegold::Serverbound::PlayerPositionAndLook < Rosegold::Serverbound::Pack
       buffer.write feet.x
       buffer.write feet.y
       buffer.write feet.z
-      buffer.write look.yaw
+      buffer.write Look.wrap_yaw(look.yaw)
       buffer.write look.pitch
 
       # MC 1.21.8 (protocol 772) format: Use bit field (0x01: on ground, 0x02: pushing against wall)

--- a/src/rosegold/packets/serverbound/use_item.cr
+++ b/src/rosegold/packets/serverbound/use_item.cr
@@ -12,7 +12,14 @@ class Rosegold::Serverbound::UseItem < Rosegold::Serverbound::Packet
 
   property hand : Hand, sequence : Int32, yaw : Float32, pitch : Float32
 
-  def initialize(@hand : Hand = Hand::MainHand, @sequence : Int32 = 0, @yaw : Float32 = 0.0_f32, @pitch : Float32 = 0.0_f32); end
+  def initialize(
+    @hand : Hand = Hand::MainHand,
+    @sequence : Int32 = 0,
+    yaw : Float32 = 0.0_f32,
+    @pitch : Float32 = 0.0_f32,
+  )
+    @yaw = Look.wrap_yaw(yaw)
+  end
 
   def write : Bytes
     Minecraft::IO::Memory.new.tap do |buffer|
@@ -21,7 +28,7 @@ class Rosegold::Serverbound::UseItem < Rosegold::Serverbound::Packet
 
       # MC 1.21+ adds sequence number, yaw, and pitch
       buffer.write sequence
-      buffer.write yaw
+      buffer.write Look.wrap_yaw(yaw)
       buffer.write pitch
     end.to_slice
   end

--- a/src/rosegold/world/look.cr
+++ b/src/rosegold/world/look.cr
@@ -16,6 +16,16 @@ struct Rosegold::Look
 
   def initialize(@yaw : Float32, @pitch : Float32); end
 
+  def self.wrap_yaw(yaw : Float32) : Float32
+    return 0.0_f32 if yaw.nan? || yaw.infinite?
+
+    wrapped = yaw.remainder(360.0_f32)
+    return wrapped - 360.0_f32 if wrapped >= 180.0_f32
+    return wrapped + 360.0_f32 if wrapped < -180.0_f32
+
+    wrapped
+  end
+
   def yaw_rad
     yaw * Math::TAU / 360
   end


### PR DESCRIPTION
## Summary

Normalize yaw consistently in `PlayerLook`, `PlayerPositionAndLook`, and `UseItem`. Serialization wraps mutable fields too, so changing a packet after construction cannot bypass the normalization.

`UseItem` previously sent raw yaw while movement packets normalized it. This keeps equivalent rotations in the same representation and uses the `[-180, 180)` boundary from `Mth.wrapDegrees`. It is client-side canonicalization, not a protocol requirement or a verified anti-cheat fix.

## Validation

- Rebased onto current main (`6499ff34`).
- Six focused yaw and serialization specs pass locally.
- Formatting and diff checks pass.
- Fresh CI is attached to the rebased head.
