### PR TITLE
Fix bucket use on cauldrons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: shards check || shards install --ignore-crystal-version
 
       - name: Run ameba linter
-        run: ./bin/ameba
+        run: crystal run lib/ameba/src/cli.cr --
 
   RunSpecs:
     if: github.repository != 'grepsedawk/sharded.cr'

--- a/shard.yml
+++ b/shard.yml
@@ -21,7 +21,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1
+    version: ~> 1.6.4
   spectator:
     github: icy-arctic-fox/spectator
     version: ~> 0.12.0

--- a/spec/integration/interactions_spec.cr
+++ b/spec/integration/interactions_spec.cr
@@ -219,6 +219,72 @@ Spectator.describe "Rosegold::Bot interactions" do
     end
   end
 
+  it "picks up water from a cauldron with one bucket" do
+    admin.setblock 0, -60, 0, "water_cauldron[level=3]"
+    admin.wait_ticks 3
+
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        admin.clear
+        admin.give "bucket"
+        admin.tp 0.5, -60, 2.5
+        bot.wait_ticks 10
+
+        bot.inventory.pick! "bucket"
+        bot.wait_ticks 5
+
+        expect(bot.main_hand.name).to eq("bucket")
+        expect(bot.main_hand.count).to eq(1)
+
+        bot.use_hand Rosegold::Vec3d.new(0.5, -59.1, 0.9)
+        bot.wait_ticks 10
+
+        expect(bot.main_hand.name).to eq("water_bucket")
+
+        cauldron_state = client.dimension_for_test.block_state(0, -60, 0).as(UInt16)
+        expect(Rosegold::MCData.default.block_state_names[cauldron_state]).to eq("cauldron")
+
+        [{-1, 0}, {1, 0}, {0, -1}, {0, 1}].each do |x_offset, z_offset|
+          state = client.dimension_for_test.block_state(x_offset, -60, z_offset).as(UInt16)
+          expect(Rosegold::MCData.default.block_state_names[state]).to eq("air")
+        end
+      end
+    end
+  end
+
+  it "uses each filled bucket on an occupied cauldron" do
+    client.join_game do |client|
+      Rosegold::Bot.new(client).try do |bot|
+        admin.tp 0.5, -60, 2.5
+        bot.wait_ticks 5
+
+        [
+          {"water_cauldron[level=1]", "water_bucket", "water_cauldron"},
+          {"water_cauldron[level=3]", "lava_bucket", "lava_cauldron"},
+          {"lava_cauldron", "powder_snow_bucket", "powder_snow_cauldron"},
+        ].each do |starting_block, bucket, expected_block|
+          admin.setblock 0, -60, 0, starting_block
+          admin.clear
+          admin.give bucket
+          bot.wait_ticks 10
+
+          bot.inventory.pick! bucket
+          bot.wait_ticks 5
+
+          bot.use_hand Rosegold::Vec3d.new(0.5, -59.1, 0.9)
+          bot.wait_ticks 10
+
+          expect(bot.main_hand.name).to eq("bucket")
+
+          cauldron_state = client.dimension_for_test.block_state(0, -60, 0).as(UInt16)
+          cauldron = Rosegold::Block.from_block_state_id(cauldron_state)
+          expect(cauldron.id_str).to eq(expected_block)
+          expect(cauldron_state).to eq(cauldron.max_state_id)
+        end
+      end
+    end
+  end
+
   it "should be able to harvest a hanging vine while walking east with pitch=40" do
     client.join_game do |client|
       Rosegold::Bot.new(client).try do |bot|

--- a/src/rosegold/control/interactions.cr
+++ b/src/rosegold/control/interactions.cr
@@ -185,7 +185,7 @@ class Rosegold::Interactions
         # Sneaking with an item in either hand bypasses block-use entirely.
         bypass_block_use = client.player.sneaking? &&
                            (inventory.main_hand.present? || inventory.off_hand.present?)
-        if bypass_block_use || !block_use_consumes_click?(reached)
+        if bypass_block_use || !block_use_consumes_click?(reached, using_hand)
           sequence = client.next_sequence
           operation = BlockOperation.new(Vec3i::ORIGIN, :use)
           client.pending_block_operations[sequence] = operation
@@ -230,9 +230,9 @@ class Rosegold::Interactions
     client.emit_event Event::ArmSwing.new(hand)
   end
 
-  # Blocks whose right-click returns vanilla Success, suppressing the UseItem
-  # fall-through. Unknown/unloaded block states do not consume.
-  private def block_use_consumes_click?(reached : ReachedBlock) : Bool
+  # Suppress UseItem fall-through when vanilla consumes the block interaction.
+  # Unknown/unloaded block states do not consume.
+  private def block_use_consumes_click?(reached : ReachedBlock, hand : Hand) : Bool
     block_state = client.dimension.block_state(reached.block)
     return false unless block_state
     block = Block.from_block_state_id(block_state)
@@ -256,6 +256,23 @@ class Rosegold::Interactions
     when .ends_with?("bed"), "flower_pot", .starts_with?("potted_"),
          .ends_with?("sign"), "bell", "cake"
       true
+    when "cauldron", "water_cauldron", "lava_cauldron", "powder_snow_cauldron"
+      cauldron_use_consumes_click?(block, block_state, hand)
+    else
+      false
+    end
+  end
+
+  private def cauldron_use_consumes_click?(block : Block, block_state : UInt16, hand : Hand) : Bool
+    held_item_name = (hand.main_hand? ? inventory.main_hand : inventory.off_hand).name
+    return true if {"water_bucket", "lava_bucket", "powder_snow_bucket"}.includes?(held_item_name)
+    return false unless held_item_name == "bucket"
+
+    case block.id_str
+    when "lava_cauldron"
+      true
+    when "water_cauldron", "powder_snow_cauldron"
+      block_state == block.max_state_id
     else
       false
     end


### PR DESCRIPTION
## Summary

- stop `UseItem` fall-through after bucket interactions that cauldrons consume
- match vanilla behavior for filled buckets and empty-bucket pickup
- cover single-bucket water pickup and filled-bucket replacement

## Why

After the block interaction fills a single bucket, the immediate `UseItem` uses the updated held item and spills it beside the cauldron. A stack of empty buckets masks the bug because the held item remains an empty bucket.

## CI

Fresh Shards 0.20 installs no longer create `bin/ameba`. They also resolve Ameba 1.7, while this repository's configuration targets 1.6.4. Pin the configured version and run it from source so cache misses behave like existing cached runs.

## Testing

- `crystal tool format --check`
- `crystal build --no-codegen src/rosegold.cr`
- `crystal run lib/ameba/src/cli.cr --` (0 failures)
- `crystal spec spec/integration/interactions_spec.cr spec/integration/eating_spec.cr` (11 examples)
- `crystal spec` (587/588; the existing disguised-chat integration test also fails on unchanged `main` against the local 26.1 server)

Closes #353
