### PR TITLE
Track server entity state

### DIFF
--- a/spec/models/movement_speed_attribute_spec.cr
+++ b/spec/models/movement_speed_attribute_spec.cr
@@ -1,0 +1,66 @@
+require "../spec_helper"
+
+Spectator.describe Rosegold::AttributeSnapshot do
+  describe "#effective_value" do
+    it "combines all three operations as (base + adds) * (1 + mul_base) * Prod(1 + mul_total)" do
+      snapshot = Rosegold::AttributeSnapshot.new(22_u32, 0.1, [
+        Rosegold::AttributeModifier.new("a", 0.05, 0_u8),
+        Rosegold::AttributeModifier.new("b", 0.5, 1_u8),
+        Rosegold::AttributeModifier.new("c", 0.2, 2_u8),
+        Rosegold::AttributeModifier.new("d", -0.1, 2_u8),
+      ])
+
+      expected = (0.1 + 0.05) * (1.0 + 0.5) * (1.0 + 0.2) * (1.0 - 0.1)
+      expect(snapshot.effective_value).to be_close(expected, 1e-9)
+    end
+
+    it "returns the base when there are no modifiers" do
+      snapshot = Rosegold::AttributeSnapshot.new(22_u32, 0.1, [] of Rosegold::AttributeModifier)
+      expect(snapshot.effective_value).to be_close(0.1, 1e-9)
+    end
+
+    it "skips excluded modifier ids" do
+      snapshot = Rosegold::AttributeSnapshot.new(22_u32, 0.1, [
+        Rosegold::AttributeModifier.new("minecraft:sprinting", 0.3, 2_u8),
+      ])
+
+      expect(snapshot.effective_value).to be_close(0.13, 1e-9)
+      expect(snapshot.effective_value(excluding: Set{"minecraft:sprinting"})).to be_close(0.1, 1e-9)
+    end
+  end
+end
+
+Spectator.describe Rosegold::Player do
+  describe "#ground_movement_speed" do
+    before_each { Rosegold::Client.protocol_version = 772_u32 }
+    after_each { Rosegold::Client.reset_protocol_version! }
+
+    it "uses the synced attribute when present, excluding the sprint modifier" do
+      player = Rosegold::Player.new
+      player.apply_attribute_snapshots([
+        Rosegold::AttributeSnapshot.new(22_u32, 0.1, [
+          Rosegold::AttributeModifier.new("minecraft:sprinting", 0.3, 2_u8),
+          Rosegold::AttributeModifier.new("minecraft:speed_effect", 0.4, 2_u8),
+        ]),
+      ])
+
+      expect(player.ground_movement_speed(0.1)).to be_close(0.1 * 1.4, 1e-9)
+    end
+
+    it "uses movement_speed's shifted 26.2 registry id" do
+      Rosegold::Client.protocol_version = 776_u32
+      player = Rosegold::Player.new
+      player.apply_attribute_snapshots([
+        Rosegold::AttributeSnapshot.new(22_u32, 0.0, [] of Rosegold::AttributeModifier),
+        Rosegold::AttributeSnapshot.new(26_u32, 0.15, [] of Rosegold::AttributeModifier),
+      ])
+
+      expect(player.ground_movement_speed(0.1)).to be_close(0.15, 1e-9)
+    end
+
+    it "falls back to the effect formula when no attribute is synced" do
+      player = Rosegold::Player.new
+      expect(player.ground_movement_speed(0.1)).to be_close(0.1, 1e-9)
+    end
+  end
+end

--- a/spec/packets/clientbound/respawn_attributes_spec.cr
+++ b/spec/packets/clientbound/respawn_attributes_spec.cr
@@ -1,0 +1,46 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::Respawn do
+  let(client) { Rosegold::Client.new("localhost", 25565, offline: {uuid: "00000000-0000-0000-0000-000000000000", username: "tester"}) }
+
+  def respawn(data_kept : UInt8)
+    Rosegold::Clientbound::Respawn.new(
+      0_u32, "minecraft:overworld", 0_i64, 0_u8, -1_i8,
+      false, false, false, nil, nil, 0_u32, 63_u32, data_kept
+    )
+  end
+
+  it "clears attributes that the respawn does not preserve" do
+    client.player.apply_attribute_snapshots([
+      Rosegold::AttributeSnapshot.new(22_u32, 0.15, [] of Rosegold::AttributeModifier),
+    ])
+
+    respawn(0_u8).callback(client)
+
+    expect(client.player.attributes).to be_empty
+  end
+
+  it "retains attributes when the respawn requests them" do
+    client.player.apply_attribute_snapshots([
+      Rosegold::AttributeSnapshot.new(22_u32, 0.15, [] of Rosegold::AttributeModifier),
+    ])
+
+    respawn(Rosegold::Clientbound::Respawn::KEEP_ATTRIBUTES).callback(client)
+
+    expect(client.player.attributes[22_u32].base).to eq(0.15)
+  end
+
+  it "clears attributes when a fresh login reuses the player" do
+    client.player.apply_attribute_snapshots([
+      Rosegold::AttributeSnapshot.new(22_u32, 0.15, [] of Rosegold::AttributeModifier),
+    ])
+
+    Rosegold::Clientbound::Login.new(
+      7, false, ["minecraft:overworld"], 20_u32, 10_u32, 10_u32,
+      false, true, false, 0_u32, "minecraft:overworld", 0_i64, 0_u8,
+      -1_i8, false, false, false, nil, nil, 0_u32, 63_u32, false
+    ).callback(client)
+
+    expect(client.player.attributes).to be_empty
+  end
+end

--- a/spec/packets/clientbound/set_entity_data_spec.cr
+++ b/spec/packets/clientbound/set_entity_data_spec.cr
@@ -1,0 +1,320 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::SetEntityData do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "uses correct packet ID for protocol 772" do
+    expect(Rosegold::Clientbound::SetEntityData[772_u32]).to eq(0x5C_u32)
+  end
+
+  it "uses correct packet ID for protocol 773" do
+    expect(Rosegold::Clientbound::SetEntityData[773_u32]).to eq(0x61_u32)
+  end
+
+  it "uses correct packet ID for protocol 774" do
+    expect(Rosegold::Clientbound::SetEntityData[774_u32]).to eq(0x61_u32)
+  end
+
+  it "uses correct packet ID for protocol 775" do
+    expect(Rosegold::Clientbound::SetEntityData[775_u32]).to eq(0x63_u32)
+  end
+
+  it "uses correct packet ID for protocol 776" do
+    expect(Rosegold::Clientbound::SetEntityData[776_u32]).to eq(0x63_u32)
+  end
+
+  it "supports all five protocols" do
+    [772_u32, 773_u32, 774_u32, 775_u32, 776_u32].each do |protocol|
+      expect(Rosegold::Clientbound::SetEntityData.supports_protocol?(protocol)).to be_true
+    end
+    expect(Rosegold::Clientbound::SetEntityData.supports_protocol?(999_u32)).to be_false
+  end
+
+  it "belongs to PLAY state" do
+    expect(Rosegold::Clientbound::SetEntityData.state).to eq(Rosegold::ProtocolState::PLAY)
+  end
+
+  it "is properly registered in PLAY state" do
+    play_state = Rosegold::ProtocolState::PLAY
+    expect(play_state.get_clientbound_packet(0x5C_u8, 772_u32)).to eq(Rosegold::Clientbound::SetEntityData)
+  end
+
+  describe "serializer tables" do
+    it "keeps indices 0-15 identical across protocols" do
+      [772_u32, 773_u32, 775_u32].each do |protocol|
+        expect(Rosegold::EntityMetadata.serializer_for(0_u32, protocol)).to eq(:byte)
+        expect(Rosegold::EntityMetadata.serializer_for(6_u32, protocol)).to eq(:opt_text_component)
+        expect(Rosegold::EntityMetadata.serializer_for(8_u32, protocol)).to eq(:boolean)
+      end
+    end
+
+    it "has an nbt serializer at 16 on 772 only" do
+      expect(Rosegold::EntityMetadata.serializer_for(16_u32, 772_u32)).to eq(:nbt)
+      expect(Rosegold::EntityMetadata.serializer_for(16_u32, 773_u32)).to eq(:particle)
+    end
+
+    it "inserts cat_sound_variant at 22 on 775, shifting cow_variant to 23" do
+      expect(Rosegold::EntityMetadata.serializer_for(22_u32, 773_u32)).to eq(:cow_variant)
+      expect(Rosegold::EntityMetadata.serializer_for(22_u32, 775_u32)).to eq(:cat_sound_variant)
+      expect(Rosegold::EntityMetadata.serializer_for(23_u32, 775_u32)).to eq(:cow_variant)
+    end
+
+    it "covers the full 772 tail through quaternion" do
+      expect(Rosegold::EntityMetadata.serializer_for(24_u32, 772_u32)).to eq(:wolf_variant)
+      expect(Rosegold::EntityMetadata.serializer_for(29_u32, 772_u32)).to eq(:opt_global_pos)
+      expect(Rosegold::EntityMetadata.serializer_for(30_u32, 772_u32)).to eq(:painting_variant)
+      expect(Rosegold::EntityMetadata.serializer_for(34_u32, 772_u32)).to eq(:quaternion)
+      expect(Rosegold::EntityMetadata.serializer_for(35_u32, 772_u32)).to be_nil
+    end
+
+    it "inserts zombie_nautilus_variant at 28 on 774 only, unlike 773" do
+      expect(Rosegold::EntityMetadata.serializer_for(28_u32, 773_u32)).to eq(:opt_global_pos)
+      expect(Rosegold::EntityMetadata.serializer_for(28_u32, 774_u32)).to eq(:zombie_nautilus_variant)
+      expect(Rosegold::EntityMetadata.serializer_for(29_u32, 774_u32)).to eq(:opt_global_pos)
+      expect(Rosegold::EntityMetadata.serializer_for(38_u32, 774_u32)).to eq(:humanoid_arm)
+      expect(Rosegold::EntityMetadata.serializer_for(37_u32, 773_u32)).to be_nil
+    end
+
+    it "runs the 775 tail out to humanoid_arm at 42" do
+      expect(Rosegold::EntityMetadata.serializer_for(29_u32, 775_u32)).to eq(:pig_sound_variant)
+      expect(Rosegold::EntityMetadata.serializer_for(34_u32, 775_u32)).to eq(:painting_variant)
+      expect(Rosegold::EntityMetadata.serializer_for(41_u32, 775_u32)).to eq(:resolvable_profile)
+      expect(Rosegold::EntityMetadata.serializer_for(42_u32, 775_u32)).to eq(:humanoid_arm)
+    end
+  end
+
+  describe "tail serializer values" do
+    it "decodes wolf_variant, vector3, quaternion and opt_global_pos on 772" do
+      Rosegold::Client.protocol_version = 772_u32
+
+      io = Minecraft::IO::Memory.new
+      io.write 7_u32
+      io.write_byte 17_u8
+      io.write 24_u32 # wolf_variant
+      io.write 3_u32
+      io.write_byte 11_u8
+      io.write 33_u32 # vector3
+      io.write_full 1.0_f32
+      io.write_full 2.0_f32
+      io.write_full 3.0_f32
+      io.write_byte 12_u8
+      io.write 34_u32 # quaternion
+      4.times { io.write_full 0.5_f32 }
+      io.write_byte 13_u8
+      io.write 29_u32 # opt_global_pos
+      io.write true
+      io.write "minecraft:overworld"
+      io.write Rosegold::Vec3i.new(1, 64, -2)
+      io.write_byte 0xFF_u8
+
+      read_io = Minecraft::IO::Memory.new(io.to_slice)
+      packet = Rosegold::Clientbound::SetEntityData.read(read_io)
+
+      expect(packet.values[17_u8]).to eq(3_u32)
+      expect(packet.values[11_u8]).to eq({1.0_f32, 2.0_f32, 3.0_f32})
+      expect(packet.values[12_u8]).to eq([0.5_f32, 0.5_f32, 0.5_f32, 0.5_f32])
+      expect(packet.values[13_u8]).to eq({"minecraft:overworld", Rosegold::Vec3i.new(1, 64, -2)})
+
+      round_trip = Minecraft::IO::Memory.new(packet.write)
+      round_trip.read_byte
+      expect(Rosegold::Clientbound::SetEntityData.read(round_trip).values).to eq(packet.values)
+    end
+
+    it "captures a registry painting_variant holder for byte-exact round-trip" do
+      Rosegold::Client.protocol_version = 772_u32
+
+      io = Minecraft::IO::Memory.new
+      io.write 7_u32
+      io.write_byte 19_u8
+      io.write 30_u32 # painting_variant
+      io.write 5_u32  # registry holder (id 4 + 1)
+      io.write_byte 0xFF_u8
+
+      packet = Rosegold::Clientbound::SetEntityData.read(Minecraft::IO::Memory.new(io.to_slice))
+      expect(packet.values[19_u8].as(Bytes)).to eq(Bytes[5])
+
+      round_trip = Minecraft::IO::Memory.new(packet.write)
+      round_trip.read_byte
+      expect(Rosegold::Clientbound::SetEntityData.read(round_trip).values[19_u8]).to eq(Bytes[5])
+    end
+
+    it "aborts on resolvable_profile" do
+      Rosegold::Client.protocol_version = 775_u32
+
+      io = Minecraft::IO::Memory.new
+      io.write 7_u32
+      io.write_byte 0_u8
+      io.write 41_u32 # resolvable_profile
+      io.write_byte 0xFF_u8
+
+      expect { Rosegold::Clientbound::SetEntityData.read(Minecraft::IO::Memory.new(io.to_slice)) }
+        .to raise_error(/resolvable_profile/)
+    end
+  end
+
+  describe "packet parsing" do
+    it "decodes entity flags and a custom name on protocol 772" do
+      Rosegold::Client.protocol_version = 772_u32
+
+      io = Minecraft::IO::Memory.new
+      io.write 42_u32       # entity_id
+      io.write_byte 0_u8    # index 0 (entity flags)
+      io.write 0_u32        # serializer: byte
+      io.write_byte 0x48_u8 # sprinting (0x08) + glowing (0x40)
+      io.write_byte 2_u8    # index 2 (custom_name)
+      io.write 6_u32        # serializer: opt_text_component
+      io.write true         # present
+      io.write Rosegold::TextComponent.new("Bob")
+      io.write_byte 0xFF_u8 # terminator
+      io.pos = 0
+
+      packet = Rosegold::Clientbound::SetEntityData.read(io)
+
+      expect(packet.entity_id).to eq(42_u64)
+      expect(packet.entries.size).to eq(2)
+      values = packet.values
+      expect(values[0_u8]).to eq(0x48_u8)
+      name = values[2_u8]
+      expect(name).to be_a(Rosegold::TextComponent)
+      expect(name.as(Rosegold::TextComponent).text).to eq("Bob")
+    end
+
+    it "decodes an nbt tracked value on protocol 772" do
+      Rosegold::Client.protocol_version = 772_u32
+
+      tag = Minecraft::NBT::CompoundTag.new(
+        {"k" => Minecraft::NBT::IntTag.new(7).as(Minecraft::NBT::Tag)} of String => Minecraft::NBT::Tag)
+
+      io = Minecraft::IO::Memory.new
+      io.write 1_u32
+      io.write_byte 5_u8 # index
+      io.write 16_u32    # serializer: nbt (772 only)
+      io.write_byte tag.tag_type
+      tag.write io
+      io.write_byte 0xFF_u8
+      io.pos = 0
+
+      packet = Rosegold::Clientbound::SetEntityData.read(io)
+
+      expect(packet.values[5_u8]).to be_a(Minecraft::NBT::Tag)
+    end
+
+    it "decodes the same shared fields on protocol 773 despite the shifted packet id" do
+      Rosegold::Client.protocol_version = 773_u32
+
+      io = Minecraft::IO::Memory.new
+      io.write 9_u32
+      io.write_byte 0_u8
+      io.write 0_u32
+      io.write_byte 0x20_u8 # invisible
+      io.write_byte 0xFF_u8
+      io.pos = 0
+
+      packet = Rosegold::Clientbound::SetEntityData.read(io)
+
+      expect(packet.values[0_u8]).to eq(0x20_u8)
+    end
+
+    it "decodes a Slot at index 8" do
+      Rosegold::Client.protocol_version = 772_u32
+
+      io = Minecraft::IO::Memory.new
+      io.write 3_u32
+      io.write_byte 8_u8 # item entity's item_stack
+      io.write 7_u32     # serializer: slot
+      io.write Rosegold::Slot.new(4_u32, 55_u32)
+      io.write_byte 0xFF_u8
+      io.pos = 0
+
+      packet = Rosegold::Clientbound::SetEntityData.read(io)
+
+      slot = packet.values[8_u8]
+      expect(slot).to be_a(Rosegold::Slot)
+      expect(slot.as(Rosegold::Slot).item_id_int).to eq(55_u32)
+    end
+
+    it "degrades to RawPacket when a particle serializer is encountered" do
+      Rosegold::Client.protocol_version = 772_u32
+
+      buffer = Minecraft::IO::Memory.new
+      buffer.write 0x5C_u32 # packet id
+      buffer.write 1_u32    # entity_id
+      buffer.write_byte 0_u8
+      buffer.write 17_u32 # serializer: particle (772) — no codec, must raise
+
+      decoded = Rosegold::Connection.decode_clientbound_packet(
+        buffer.to_slice, Rosegold::ProtocolState::PLAY, 772_u32)
+
+      expect(decoded).to be_a(Rosegold::Clientbound::RawPacket)
+    end
+  end
+
+  describe "callback behavior" do
+    let(client) { Rosegold::Client.new("localhost", 25565, offline: {uuid: "00000000-0000-0000-0000-000000000000", username: "tester"}) }
+
+    def tracked_entity
+      Rosegold::Entity.new(
+        7_u32, UUID.random, 1_u32,
+        Rosegold::Vec3d.new(0.0, 0.0, 0.0),
+        0.0_f32, 0.0_f32, 0.0_f32,
+        Rosegold::Vec3d.new(0.0, 0.0, 0.0))
+    end
+
+    it "merges partial updates rather than replacing tracked_data" do
+      entity = tracked_entity
+      entity.tracked_data[9_u8] = "keep"
+      entity.tracked_data[0_u8] = 0x01_u8
+      client.dimension_for_test.entities[7_u64] = entity
+
+      packet = Rosegold::Clientbound::SetEntityData.new(
+        7_u64, [Rosegold::Clientbound::SetEntityData::Entry.new(0_u8, 0_u32, 0x08_u8.as(Rosegold::Entity::TrackedValue))])
+      packet.callback(client)
+
+      expect(entity.tracked_data[0_u8]).to eq(0x08_u8)
+      expect(entity.tracked_data[9_u8]).to eq("keep")
+      expect(entity.sprinting?).to be_true
+    end
+
+    it "no-ops for an unknown entity" do
+      packet = Rosegold::Clientbound::SetEntityData.new(
+        123_u64, [Rosegold::Clientbound::SetEntityData::Entry.new(0_u8, 0_u32, 0x01_u8.as(Rosegold::Entity::TrackedValue))])
+
+      expect { packet.callback(client) }.not_to raise_error
+    end
+  end
+
+  describe "round-trip serialization" do
+    it "preserves the decodable serializer subset" do
+      Rosegold::Client.protocol_version = 772_u32
+
+      entries = [
+        Rosegold::Clientbound::SetEntityData::Entry.new(0_u8, 0_u32, 0x08_u8.as(Rosegold::Entity::TrackedValue)),
+        Rosegold::Clientbound::SetEntityData::Entry.new(1_u8, 1_u32, 300_u32.as(Rosegold::Entity::TrackedValue)),
+        Rosegold::Clientbound::SetEntityData::Entry.new(3_u8, 3_u32, 2.5_f32.as(Rosegold::Entity::TrackedValue)),
+        Rosegold::Clientbound::SetEntityData::Entry.new(4_u8, 4_u32, "hi".as(Rosegold::Entity::TrackedValue)),
+        Rosegold::Clientbound::SetEntityData::Entry.new(8_u8, 7_u32, Rosegold::Slot.new(2_u32, 9_u32).as(Rosegold::Entity::TrackedValue)),
+        Rosegold::Clientbound::SetEntityData::Entry.new(11_u8, 9_u32, {1.0_f32, 2.0_f32, 3.0_f32}.as(Rosegold::Entity::TrackedValue)),
+        Rosegold::Clientbound::SetEntityData::Entry.new(12_u8, 10_u32, Rosegold::Vec3i.new(4, 5, 6).as(Rosegold::Entity::TrackedValue)),
+        Rosegold::Clientbound::SetEntityData::Entry.new(20_u8, 19_u32, [1_u32, 2_u32, 3_u32].as(Rosegold::Entity::TrackedValue)),
+      ]
+      original = Rosegold::Clientbound::SetEntityData.new(88_u64, entries)
+
+      io = Minecraft::IO::Memory.new(original.write)
+      io.read_byte # skip packet id
+
+      read = Rosegold::Clientbound::SetEntityData.read(io)
+
+      expect(read.entity_id).to eq(88_u64)
+      expect(read.entries.size).to eq(8)
+      values = read.values
+      expect(values[0_u8]).to eq(0x08_u8)
+      expect(values[1_u8]).to eq(300_u32)
+      expect(values[3_u8]).to eq(2.5_f32)
+      expect(values[4_u8]).to eq("hi")
+      expect(values[8_u8].as(Rosegold::Slot).item_id_int).to eq(9_u32)
+      expect(values[11_u8]).to eq({1.0_f32, 2.0_f32, 3.0_f32})
+      expect(values[12_u8].as(Rosegold::Vec3i)).to eq(Rosegold::Vec3i.new(4, 5, 6))
+      expect(values[20_u8]).to eq([1_u32, 2_u32, 3_u32])
+    end
+  end
+end

--- a/spec/packets/clientbound/teleport_entity_spec.cr
+++ b/spec/packets/clientbound/teleport_entity_spec.cr
@@ -1,0 +1,178 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::TeleportEntity do
+  let(client) { Rosegold::Client.new("localhost", 25565, offline: {uuid: "00000000-0000-0000-0000-000000000000", username: "tester"}) }
+
+  it "uses correct packet ID per protocol" do
+    expect(Rosegold::Clientbound::TeleportEntity[772_u32]).to eq(0x76_u8)
+    expect(Rosegold::Clientbound::TeleportEntity[773_u32]).to eq(0x7B_u8)
+    expect(Rosegold::Clientbound::TeleportEntity[774_u32]).to eq(0x7B_u8)
+    expect(Rosegold::Clientbound::TeleportEntity[775_u32]).to eq(0x7D_u8)
+    expect(Rosegold::Clientbound::TeleportEntity[776_u32]).to eq(0x7D_u8)
+  end
+
+  it "supports exactly the five mapped protocols" do
+    expect(Rosegold::Clientbound::TeleportEntity.supports_protocol?(772_u32)).to be_true
+    expect(Rosegold::Clientbound::TeleportEntity.supports_protocol?(776_u32)).to be_true
+    expect(Rosegold::Clientbound::TeleportEntity.supports_protocol?(999_u32)).to be_false
+  end
+
+  it "belongs to PLAY state" do
+    expect(Rosegold::Clientbound::TeleportEntity.state).to eq(Rosegold::ProtocolState::PLAY)
+  end
+
+  it "is properly registered in PLAY state" do
+    play_state = Rosegold::ProtocolState::PLAY
+    expect(play_state.get_clientbound_packet(0x76_u8, 772_u32)).to eq(Rosegold::Clientbound::TeleportEntity)
+    expect(play_state.get_clientbound_packet(0x7D_u8, 776_u32)).to eq(Rosegold::Clientbound::TeleportEntity)
+  end
+
+  describe "read/write round-trip" do
+    it "preserves every field through a write/read cycle" do
+      original = Rosegold::Clientbound::TeleportEntity.new(
+        42_u64,
+        1.5, -60.0, 2.25,
+        0.1, -0.2, 0.3,
+        90.0_f32, -45.0_f32,
+        0b10101010_i32,
+        true
+      )
+
+      bytes = original.write
+      io = Minecraft::IO::Memory.new(bytes)
+      io.read_byte
+      read_back = Rosegold::Clientbound::TeleportEntity.read(io)
+
+      expect(read_back.entity_id).to eq(42_u64)
+      expect(read_back.x).to eq(1.5)
+      expect(read_back.y).to eq(-60.0)
+      expect(read_back.z).to eq(2.25)
+      expect(read_back.velocity_x).to be_close(0.1, 0.0001)
+      expect(read_back.velocity_y).to be_close(-0.2, 0.0001)
+      expect(read_back.velocity_z).to be_close(0.3, 0.0001)
+      expect(read_back.yaw).to eq(90.0_f32)
+      expect(read_back.pitch).to eq(-45.0_f32)
+      expect(read_back.relatives).to eq(0b10101010_i32)
+      expect(read_back.on_ground?).to be_true
+    end
+  end
+
+  describe "relative-bit resolution" do
+    it "rotates prior velocity before applying relative velocity" do
+      packet = Rosegold::Clientbound::TeleportEntity.new(
+        1_u64, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0_f32, 0.0_f32,
+        (1 << Rosegold::Clientbound::TeleportEntity::BIT_ROTATE_DELTA) |
+        (1 << Rosegold::Clientbound::TeleportEntity::BIT_DELTA_X) |
+        (1 << Rosegold::Clientbound::TeleportEntity::BIT_DELTA_Y) |
+        (1 << Rosegold::Clientbound::TeleportEntity::BIT_DELTA_Z), false
+      )
+
+      velocity = packet.resolved_velocity(Rosegold::Vec3d.new(0.0, 0.0, 1.0), 90.0_f32, 0.0_f32)
+
+      expect(velocity.x).to be_close(1.0, 1e-6)
+      expect(velocity.y).to be_close(0.0, 1e-6)
+      expect(velocity.z).to be_close(0.0, 1e-6)
+    end
+
+    it "treats relatives == 0 as fully absolute" do
+      packet = Rosegold::Clientbound::TeleportEntity.new(
+        1_u64, 10.0, 20.0, 30.0, 1.0, 2.0, 3.0, 45.0_f32, 15.0_f32, 0_i32, false
+      )
+      current_pos = Rosegold::Vec3d.new(100.0, 200.0, 300.0)
+      current_vel = Rosegold::Vec3d.new(9.0, 9.0, 9.0)
+
+      resolved_pos = packet.resolved_position(current_pos)
+      resolved_vel = packet.resolved_velocity(current_vel)
+
+      expect(resolved_pos).to eq(Rosegold::Vec3d.new(10.0, 20.0, 30.0))
+      expect(resolved_vel).to eq(Rosegold::Vec3d.new(1.0, 2.0, 3.0))
+      expect(packet.resolved_yaw(50.0_f32)).to eq(45.0_f32)
+      expect(packet.resolved_pitch(50.0_f32)).to eq(15.0_f32)
+    end
+
+    it "adds every field to the current value when all bits are set" do
+      relatives = (1 << Rosegold::Clientbound::TeleportEntity::BIT_X) |
+                  (1 << Rosegold::Clientbound::TeleportEntity::BIT_Y) |
+                  (1 << Rosegold::Clientbound::TeleportEntity::BIT_Z) |
+                  (1 << Rosegold::Clientbound::TeleportEntity::BIT_YAW) |
+                  (1 << Rosegold::Clientbound::TeleportEntity::BIT_PITCH) |
+                  (1 << Rosegold::Clientbound::TeleportEntity::BIT_DELTA_X) |
+                  (1 << Rosegold::Clientbound::TeleportEntity::BIT_DELTA_Y) |
+                  (1 << Rosegold::Clientbound::TeleportEntity::BIT_DELTA_Z)
+
+      packet = Rosegold::Clientbound::TeleportEntity.new(
+        1_u64, 1.0, 2.0, 3.0, 0.5, 0.5, 0.5, 10.0_f32, 5.0_f32, relatives, false
+      )
+      current_pos = Rosegold::Vec3d.new(100.0, 200.0, 300.0)
+      current_vel = Rosegold::Vec3d.new(1.0, 1.0, 1.0)
+
+      expect(packet.resolved_position(current_pos)).to eq(Rosegold::Vec3d.new(101.0, 202.0, 303.0))
+      expect(packet.resolved_velocity(current_vel)).to eq(Rosegold::Vec3d.new(1.5, 1.5, 1.5))
+      expect(packet.resolved_yaw(90.0_f32)).to eq(100.0_f32)
+      expect(packet.resolved_pitch(20.0_f32)).to eq(25.0_f32)
+    end
+
+    it "resolves a mix of absolute and relative bits per axis" do
+      relatives = (1 << Rosegold::Clientbound::TeleportEntity::BIT_X) |
+                  (1 << Rosegold::Clientbound::TeleportEntity::BIT_PITCH) |
+                  (1 << Rosegold::Clientbound::TeleportEntity::BIT_DELTA_Z)
+
+      packet = Rosegold::Clientbound::TeleportEntity.new(
+        1_u64, 5.0, 5.0, 5.0, 1.0, 1.0, 1.0, 0.0_f32, 5.0_f32, relatives, false
+      )
+      current_pos = Rosegold::Vec3d.new(100.0, 200.0, 300.0)
+      current_vel = Rosegold::Vec3d.new(0.0, 0.0, 0.0)
+
+      resolved_pos = packet.resolved_position(current_pos)
+      expect(resolved_pos.x).to eq(105.0)
+      expect(resolved_pos.y).to eq(5.0)
+      expect(resolved_pos.z).to eq(5.0)
+
+      resolved_vel = packet.resolved_velocity(current_vel)
+      expect(resolved_vel.x).to eq(1.0)
+      expect(resolved_vel.y).to eq(1.0)
+      expect(resolved_vel.z).to eq(1.0)
+
+      expect(packet.resolved_yaw(90.0_f32)).to eq(0.0_f32)
+      expect(packet.resolved_pitch(90.0_f32)).to eq(90.0_f32)
+    end
+  end
+
+  describe "callback" do
+    it "updates a tracked entity's position, velocity, yaw, pitch, and on_ground" do
+      c = client
+      entity = Rosegold::Entity.new(
+        7_u32,
+        UUID.random,
+        1_u32,
+        Rosegold::Vec3d.new(0.0, 0.0, 0.0),
+        0.0_f32, 0.0_f32, 0.0_f32,
+        Rosegold::Vec3d.new(0.0, 0.0, 0.0)
+      )
+      c.dimension_for_test.entities[7_u64] = entity
+
+      packet = Rosegold::Clientbound::TeleportEntity.new(
+        7_u64, 12.0, 34.0, 56.0, 0.1, 0.2, 0.3, 90.0_f32, -30.0_f32, 0_i32, true
+      )
+      packet.callback(c)
+
+      updated = c.dimension_for_test.entities[7_u64]
+      expect(updated.position).to eq(Rosegold::Vec3d.new(12.0, 34.0, 56.0))
+      expect(updated.velocity).to eq(Rosegold::Vec3d.new(0.1, 0.2, 0.3))
+      expect(updated.yaw).to eq(90.0_f32)
+      expect(updated.pitch).to eq(-30.0_f32)
+      expect(updated.on_ground?).to be_true
+    end
+
+    it "no-ops when the entity is not tracked" do
+      c = client
+      packet = Rosegold::Clientbound::TeleportEntity.new(
+        999_u64, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0_f32, 0.0_f32, 0_i32, false
+      )
+
+      packet.callback(c)
+
+      expect(c.dimension_for_test.entities.has_key?(999_u64)).to be_false
+    end
+  end
+end

--- a/spec/packets/clientbound/update_attributes_spec.cr
+++ b/spec/packets/clientbound/update_attributes_spec.cr
@@ -1,0 +1,114 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::UpdateAttributes do
+  let(client) { Rosegold::Client.new("localhost", 25565, offline: {uuid: "00000000-0000-0000-0000-000000000000", username: "tester"}) }
+
+  it "uses correct packet ID per protocol" do
+    expect(Rosegold::Clientbound::UpdateAttributes[772_u32]).to eq(0x7C_u8)
+    expect(Rosegold::Clientbound::UpdateAttributes[773_u32]).to eq(0x81_u8)
+    expect(Rosegold::Clientbound::UpdateAttributes[774_u32]).to eq(0x81_u8)
+    expect(Rosegold::Clientbound::UpdateAttributes[775_u32]).to eq(0x83_u8)
+    expect(Rosegold::Clientbound::UpdateAttributes[776_u32]).to eq(0x83_u8)
+  end
+
+  it "supports exactly the five mapped protocols" do
+    expect(Rosegold::Clientbound::UpdateAttributes.supports_protocol?(772_u32)).to be_true
+    expect(Rosegold::Clientbound::UpdateAttributes.supports_protocol?(776_u32)).to be_true
+    expect(Rosegold::Clientbound::UpdateAttributes.supports_protocol?(999_u32)).to be_false
+  end
+
+  it "belongs to PLAY state" do
+    expect(Rosegold::Clientbound::UpdateAttributes.state).to eq(Rosegold::ProtocolState::PLAY)
+  end
+
+  it "is properly registered in PLAY state" do
+    play_state = Rosegold::ProtocolState::PLAY
+    expect(play_state.get_clientbound_packet(0x7C_u8, 772_u32)).to eq(Rosegold::Clientbound::UpdateAttributes)
+    expect(play_state.get_clientbound_packet(0x83_u8, 776_u32)).to eq(Rosegold::Clientbound::UpdateAttributes)
+  end
+
+  describe "read/write round-trip" do
+    before_each { Rosegold::Client.protocol_version = 772_u32 }
+    after_each { Rosegold::Client.reset_protocol_version! }
+
+    it "preserves entity id, bases, and modifiers across operations" do
+      original = Rosegold::Clientbound::UpdateAttributes.new(
+        7_u64,
+        [
+          Rosegold::AttributeSnapshot.new(22_u32, 0.1, [
+            Rosegold::AttributeModifier.new("minecraft:sprinting", 0.3, 2_u8),
+            Rosegold::AttributeModifier.new("minecraft:base_boost", 0.05, 0_u8),
+          ]),
+          Rosegold::AttributeSnapshot.new(2_u32, 4.0, [] of Rosegold::AttributeModifier),
+        ]
+      )
+
+      io = Minecraft::IO::Memory.new(original.write)
+      io.read_var_int
+      read_back = Rosegold::Clientbound::UpdateAttributes.read(io)
+
+      expect(read_back.entity_id).to eq(7_u64)
+      expect(read_back.attribute_snapshots.size).to eq(2)
+
+      speed = read_back.attribute_snapshots[0]
+      expect(speed.attribute_id).to eq(22_u32)
+      expect(speed.base).to be_close(0.1, 1e-9)
+      expect(speed.modifiers.size).to eq(2)
+      expect(speed.modifiers[0].id).to eq("minecraft:sprinting")
+      expect(speed.modifiers[0].amount).to be_close(0.3, 1e-9)
+      expect(speed.modifiers[0].operation).to eq(2_u8)
+      expect(speed.modifiers[1].id).to eq("minecraft:base_boost")
+      expect(speed.modifiers[1].operation).to eq(0_u8)
+
+      damage = read_back.attribute_snapshots[1]
+      expect(damage.attribute_id).to eq(2_u32)
+      expect(damage.base).to be_close(4.0, 1e-9)
+      expect(damage.modifiers).to be_empty
+    end
+  end
+
+  describe "callback" do
+    before_each { Rosegold::Client.protocol_version = 772_u32 }
+    after_each { Rosegold::Client.reset_protocol_version! }
+
+    it "replaces attribute entries on a tracked entity" do
+      c = client
+      entity = Rosegold::Entity.new(
+        7_u32, UUID.random, 1_u32,
+        Rosegold::Vec3d.new(0.0, 0.0, 0.0),
+        0.0_f32, 0.0_f32, 0.0_f32,
+        Rosegold::Vec3d.new(0.0, 0.0, 0.0)
+      )
+      c.dimension_for_test.entities[7_u64] = entity
+
+      Rosegold::Clientbound::UpdateAttributes.new(
+        7_u64, [Rosegold::AttributeSnapshot.new(22_u32, 0.15, [] of Rosegold::AttributeModifier)]
+      ).callback(c)
+
+      expect(c.dimension_for_test.entities[7_u64].attributes[22_u32].base).to eq(0.15)
+    end
+
+    it "stores attributes on the player when the packet targets the bot's entity" do
+      c = client
+      c.player.entity_id = 99_u64
+
+      Rosegold::Clientbound::UpdateAttributes.new(
+        99_u64, [Rosegold::AttributeSnapshot.new(22_u32, 0.2, [] of Rosegold::AttributeModifier)]
+      ).callback(c)
+
+      expect(c.player.movement_speed_attribute.try(&.base)).to eq(0.2)
+    end
+
+    it "no-ops for an untracked entity that is not the bot" do
+      c = client
+      c.player.entity_id = 1_u64
+
+      Rosegold::Clientbound::UpdateAttributes.new(
+        555_u64, [Rosegold::AttributeSnapshot.new(22_u32, 0.3, [] of Rosegold::AttributeModifier)]
+      ).callback(c)
+
+      expect(c.dimension_for_test.entities.has_key?(555_u64)).to be_false
+      expect(c.player.attributes).to be_empty
+    end
+  end
+end

--- a/src/rosegold/control/physics.cr
+++ b/src/rosegold/control/physics.cr
@@ -552,8 +552,7 @@ class Rosegold::Physics
       slip = block_slip
       friction_cubed = slip * slip * slip
       # Correct Minecraft formula: base_speed * (friction_constant / friction³)
-      # Apply Speed and Slowness potion effects to base movement speed
-      effective_speed = Math.max(0.0, BASE_MOVEMENT_SPEED * (1.0 + 0.2 * player.speed_level) * (1.0 - 0.15 * player.slowness_level))
+      effective_speed = player.ground_movement_speed(BASE_MOVEMENT_SPEED)
       movement_multiplier = effective_speed * (FRICTION_CONSTANT / friction_cubed)
 
       # Apply movement state modifiers

--- a/src/rosegold/packets/clientbound/login.cr
+++ b/src/rosegold/packets/clientbound/login.cr
@@ -138,6 +138,7 @@ class Rosegold::Clientbound::Login < Rosegold::Clientbound::Packet
   end
 
   def callback(client)
+    client.player.clear_attributes
     client.player.entity_id = entity_id.to_u64
     client.player.gamemode = gamemode.to_i8
 

--- a/src/rosegold/packets/clientbound/respawn.cr
+++ b/src/rosegold/packets/clientbound/respawn.cr
@@ -3,6 +3,7 @@ require "../../world/vec3"
 
 class Rosegold::Clientbound::Respawn < Rosegold::Clientbound::Packet
   include Rosegold::Packets::ProtocolMapping
+  KEEP_ATTRIBUTES = 0x01_u8
   packet_ids({
     772_u32 => 0x4B_u32, # MC 1.21.8
     774_u32 => 0x50_u32, # MC 1.21.11
@@ -93,6 +94,7 @@ class Rosegold::Clientbound::Respawn < Rosegold::Clientbound::Packet
 
   def callback(client)
     client.physics.pause
+    client.player.clear_attributes unless data_kept & KEEP_ATTRIBUTES != 0
     client.player.gamemode = gamemode.to_i8
 
     client.dimension = Dimension.from_registry(dimension_name, dimension_type, client.registries)

--- a/src/rosegold/packets/clientbound/set_entity_data.cr
+++ b/src/rosegold/packets/clientbound/set_entity_data.cr
@@ -1,0 +1,169 @@
+require "../packet"
+require "../../world/entity_metadata"
+
+class Rosegold::Clientbound::SetEntityData < Rosegold::Clientbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+  packet_ids({
+    772_u32 => 0x5C_u32, # MC 1.21.8
+    773_u32 => 0x61_u32, # MC 1.21.9
+    774_u32 => 0x61_u32, # MC 1.21.11
+    775_u32 => 0x63_u32, # MC 26.1
+    776_u32 => 0x63_u32, # MC 26.2
+  })
+  class_getter state = ProtocolState::PLAY
+
+  VARINT_SERIALIZERS = {
+    :varint, :direction, :pose, :opt_varint,
+    :block_state, :opt_block_state, :cat_variant, :cat_sound_variant,
+    :cow_variant, :cow_sound_variant, :wolf_variant, :wolf_sound_variant,
+    :frog_variant, :pig_variant, :pig_sound_variant, :chicken_variant,
+    :chicken_sound_variant, :zombie_nautilus_variant, :sniffer_state,
+    :armadillo_state, :copper_golem_state, :weathering_copper_state,
+    :humanoid_arm,
+  }
+
+  record Entry, index : UInt8, serializer_id : UInt32, value : Rosegold::Entity::TrackedValue
+
+  property entity_id : UInt64
+  property entries : Array(Entry)
+
+  def initialize(@entity_id, @entries); end
+
+  def self.read(packet)
+    entity_id = packet.read_var_int.to_u64
+    entries = [] of Entry
+    loop do
+      index = packet.read_byte
+      break if index == 0xFF_u8
+      serializer_id = packet.read_var_int
+      symbol = Rosegold::EntityMetadata.serializer_for(serializer_id, Client.protocol_version)
+      raise "Unknown entity metadata serializer #{serializer_id} for protocol #{Client.protocol_version}" if symbol.nil?
+      entries << Entry.new(index, serializer_id, read_value(packet, symbol))
+    end
+    new(entity_id, entries)
+  end
+
+  private def self.read_value(io, symbol : Symbol) : Rosegold::Entity::TrackedValue
+    case symbol
+    when :byte               then io.read_byte
+    when :long               then io.read_var_long
+    when :float              then io.read_float
+    when :string             then io.read_var_string
+    when :boolean            then io.read_bool
+    when :text_component     then io.read_text_component
+    when :opt_text_component then io.read_bool ? io.read_text_component : nil
+    when :slot               then Rosegold::Slot.read(io)
+    when :rotations          then {io.read_float, io.read_float, io.read_float}
+    when :block_pos          then io.read_bit_location
+    when :opt_block_pos      then io.read_bool ? io.read_bit_location : nil
+    when :opt_uuid           then io.read_bool ? io.read_uuid : nil
+    when :nbt                then io.read_nbt_unamed
+    when :villager_data      then [io.read_var_int, io.read_var_int, io.read_var_int]
+    when :opt_global_pos     then io.read_bool ? {io.read_var_string, io.read_bit_location} : nil
+    when :vector3            then {io.read_float, io.read_float, io.read_float}
+    when :quaternion         then [io.read_float, io.read_float, io.read_float, io.read_float]
+    when :painting_variant   then read_painting_variant(io)
+    when :particle, :particles, :resolvable_profile
+      raise "Entity metadata serializer #{symbol} has no stream codec; cannot advance IO"
+    else
+      raise "Unhandled entity metadata serializer #{symbol}" unless VARINT_SERIALIZERS.includes?(symbol)
+      io.read_var_int
+    end
+  end
+
+  # Holder<PaintingVariant>: VarInt where 0 = inline body follows (width,
+  # height, asset id, optional title/author components). Captured raw so write
+  # can replay the bytes without modeling the inline struct.
+  private def self.read_painting_variant(io) : Bytes
+    capture = Minecraft::IO::CaptureIO.new(io)
+    holder = capture.read_var_int
+    if holder == 0
+      capture.read_var_int
+      capture.read_var_int
+      capture.read_var_string
+      capture.read_text_component if capture.read_bool
+      capture.read_text_component if capture.read_bool
+    end
+    capture.buffer.to_slice.dup
+  end
+
+  def values : Hash(UInt8, Rosegold::Entity::TrackedValue)
+    result = Hash(UInt8, Rosegold::Entity::TrackedValue).new
+    entries.each { |entry| result[entry.index] = entry.value }
+    result
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      buffer.write entity_id.to_u32
+      entries.each do |entry|
+        buffer.write_byte entry.index
+        buffer.write entry.serializer_id
+        write_value(buffer, entry.serializer_id, entry.value)
+      end
+      buffer.write_byte 0xFF_u8
+    end.to_slice
+  end
+
+  private def write_value(io, serializer_id : UInt32, value : Rosegold::Entity::TrackedValue) : Nil
+    symbol = Rosegold::EntityMetadata.serializer_for(serializer_id, Client.protocol_version)
+    case symbol
+    when :byte           then io.write_byte value.as(UInt8)
+    when :long           then io.write value.as(UInt64)
+    when :float          then io.write_full value.as(Float32)
+    when :string         then io.write value.as(String)
+    when :boolean        then io.write value.as(Bool)
+    when :text_component then io.write value.as(Rosegold::TextComponent)
+    when :opt_text_component
+      write_optional(io, value) { |present| io.write present.as(Rosegold::TextComponent) }
+    when :slot then io.write value.as(Rosegold::Slot)
+    when :rotations
+      rotation = value.as(Tuple(Float32, Float32, Float32))
+      io.write_full rotation[0]
+      io.write_full rotation[1]
+      io.write_full rotation[2]
+    when :block_pos then io.write value.as(Rosegold::Vec3i)
+    when :opt_block_pos
+      write_optional(io, value) { |present| io.write present.as(Rosegold::Vec3i) }
+    when :opt_uuid
+      write_optional(io, value) { |present| io.write present.as(UUID) }
+    when :nbt
+      tag = value.as(Minecraft::NBT::Tag)
+      io.write_byte tag.tag_type
+      tag.write io
+    when :villager_data
+      value.as(Array(UInt32)).each { |element| io.write element }
+    when :opt_global_pos
+      write_optional(io, value) do |present|
+        dimension, pos = present.as(Tuple(String, Rosegold::Vec3i))
+        io.write dimension
+        io.write pos
+      end
+    when :vector3
+      value.as(Tuple(Float32, Float32, Float32)).each { |component| io.write_full component }
+    when :quaternion
+      value.as(Array(Float32)).each { |component| io.write_full component }
+    when :painting_variant
+      io.write value.as(Bytes)
+    else
+      raise "Unhandled entity metadata serializer #{symbol}" unless VARINT_SERIALIZERS.includes?(symbol)
+      io.write value.as(UInt32)
+    end
+  end
+
+  private def write_optional(io, value : Rosegold::Entity::TrackedValue, &)
+    if present = value
+      io.write true
+      yield present
+    else
+      io.write false
+    end
+  end
+
+  def callback(client)
+    if entity = client.dimension.entities[entity_id]?
+      entity.tracked_data.merge!(values)
+    end
+  end
+end

--- a/src/rosegold/packets/clientbound/teleport_entity.cr
+++ b/src/rosegold/packets/clientbound/teleport_entity.cr
@@ -1,0 +1,136 @@
+require "../packet"
+
+class Rosegold::Clientbound::TeleportEntity < Rosegold::Clientbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+  packet_ids({
+    772_u32 => 0x76_u32, # MC 1.21.8
+    774_u32 => 0x7B_u32, # MC 1.21.11
+    773_u32 => 0x7B_u32, # MC 1.21.9
+    775_u32 => 0x7D_u32, # MC 26.1
+    776_u32 => 0x7D_u32, # MC 26.2
+  })
+  class_getter state = ProtocolState::PLAY
+
+  BIT_X               =     0
+  BIT_Y               =     1
+  BIT_Z               =     2
+  BIT_YAW             =     3
+  BIT_PITCH           =     4
+  BIT_DELTA_X         =     5
+  BIT_DELTA_Y         =     6
+  BIT_DELTA_Z         =     7
+  BIT_ROTATE_DELTA    =     8
+  SUPPORTED_RELATIVES = 0x1FF
+
+  property \
+    entity_id : UInt64,
+    x : Float64,
+    y : Float64,
+    z : Float64,
+    velocity_x : Float64,
+    velocity_y : Float64,
+    velocity_z : Float64,
+    yaw : Float32,
+    pitch : Float32,
+    relatives : Int32
+
+  property? on_ground : Bool
+
+  def initialize(@entity_id, @x, @y, @z, @velocity_x, @velocity_y, @velocity_z, @yaw, @pitch, @relatives, @on_ground)
+    raise ArgumentError.new("TeleportEntity includes unsupported relative flags") if (@relatives & ~SUPPORTED_RELATIVES) != 0
+  end
+
+  def self.read(packet)
+    entity_id = packet.read_var_int.to_u64
+    x = packet.read_double
+    y = packet.read_double
+    z = packet.read_double
+    velocity_x = packet.read_double
+    velocity_y = packet.read_double
+    velocity_z = packet.read_double
+    yaw = packet.read_float
+    pitch = packet.read_float
+    relatives = packet.read_int
+    on_ground = packet.read_bool
+
+    self.new(entity_id, x, y, z, velocity_x, velocity_y, velocity_z, yaw, pitch, relatives, on_ground)
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      buffer.write entity_id.to_u32
+      buffer.write_full x
+      buffer.write_full y
+      buffer.write_full z
+      buffer.write_full velocity_x
+      buffer.write_full velocity_y
+      buffer.write_full velocity_z
+      buffer.write_full yaw
+      buffer.write_full pitch
+      buffer.write_full relatives
+      buffer.write on_ground?
+    end.to_slice
+  end
+
+  def relative?(bit : Int32) : Bool
+    (relatives & (1 << bit)) != 0
+  end
+
+  def resolved_position(current : Vec3d) : Vec3d
+    Vec3d.new(
+      relative?(BIT_X) ? current.x + x : x,
+      relative?(BIT_Y) ? current.y + y : y,
+      relative?(BIT_Z) ? current.z + z : z,
+    )
+  end
+
+  def resolved_velocity(current : Vec3d, current_yaw : Float32 = 0.0_f32, current_pitch : Float32 = 0.0_f32) : Vec3d
+    current = rotate_velocity(current, current_yaw, current_pitch) if relative?(BIT_ROTATE_DELTA)
+
+    Vec3d.new(
+      relative?(BIT_DELTA_X) ? current.x + velocity_x : velocity_x,
+      relative?(BIT_DELTA_Y) ? current.y + velocity_y : velocity_y,
+      relative?(BIT_DELTA_Z) ? current.z + velocity_z : velocity_z,
+    )
+  end
+
+  def resolved_yaw(current : Float32) : Float32
+    relative?(BIT_YAW) ? current + yaw : yaw
+  end
+
+  def resolved_pitch(current : Float32) : Float32
+    (relative?(BIT_PITCH) ? current + pitch : pitch).clamp(-90.0_f32, 90.0_f32)
+  end
+
+  def callback(client)
+    entity = client.dimension.entities[entity_id]?
+    return unless entity
+
+    current_yaw = entity.yaw
+    current_pitch = entity.pitch
+
+    entity.position = resolved_position(entity.position)
+    entity.yaw = resolved_yaw(current_yaw)
+    entity.pitch = resolved_pitch(current_pitch)
+    entity.velocity = resolved_velocity(entity.velocity, current_yaw, current_pitch)
+    entity.on_ground = on_ground?
+  end
+
+  private def rotate_velocity(velocity : Vec3d, current_yaw : Float32, current_pitch : Float32) : Vec3d
+    pitch_delta = (current_pitch - resolved_pitch(current_pitch)) * Math::PI / 180.0
+    yaw_delta = (current_yaw - resolved_yaw(current_yaw)) * Math::PI / 180.0
+
+    x_rotated = Vec3d.new(
+      velocity.x,
+      velocity.y * Math.cos(pitch_delta) + velocity.z * Math.sin(pitch_delta),
+      velocity.z * Math.cos(pitch_delta) - velocity.y * Math.sin(pitch_delta),
+    )
+
+    Vec3d.new(
+      x_rotated.x * Math.cos(yaw_delta) + x_rotated.z * Math.sin(yaw_delta),
+      x_rotated.y,
+      x_rotated.z * Math.cos(yaw_delta) - x_rotated.x * Math.sin(yaw_delta),
+    )
+  end
+end

--- a/src/rosegold/packets/clientbound/update_attributes.cr
+++ b/src/rosegold/packets/clientbound/update_attributes.cr
@@ -1,0 +1,64 @@
+require "../packet"
+
+class Rosegold::Clientbound::UpdateAttributes < Rosegold::Clientbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+  packet_ids({
+    772_u32 => 0x7C_u32, # MC 1.21.8
+    773_u32 => 0x81_u32, # MC 1.21.9
+    774_u32 => 0x81_u32, # MC 1.21.11
+    775_u32 => 0x83_u32, # MC 26.1
+    776_u32 => 0x83_u32, # MC 26.2
+  })
+  class_getter state = ProtocolState::PLAY
+
+  property entity_id : UInt64
+  property attribute_snapshots : Array(Rosegold::AttributeSnapshot)
+
+  def initialize(@entity_id, @attribute_snapshots)
+  end
+
+  def self.read(packet)
+    entity_id = packet.read_var_int.to_u64
+    count = packet.read_var_int
+    snapshots = Array(Rosegold::AttributeSnapshot).new(count) do
+      attribute_id = packet.read_var_int
+      base = packet.read_double
+      modifier_count = packet.read_var_int
+      modifiers = Array(Rosegold::AttributeModifier).new(modifier_count) do
+        id = packet.read_var_string
+        amount = packet.read_double
+        operation = packet.read_var_int.to_u8
+        Rosegold::AttributeModifier.new(id, amount, operation)
+      end
+      Rosegold::AttributeSnapshot.new(attribute_id, base, modifiers)
+    end
+    self.new(entity_id, snapshots)
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      buffer.write entity_id.to_u32
+      buffer.write attribute_snapshots.size.to_u32
+      attribute_snapshots.each do |snapshot|
+        buffer.write snapshot.attribute_id
+        buffer.write_full snapshot.base
+        buffer.write snapshot.modifiers.size.to_u32
+        snapshot.modifiers.each do |modifier|
+          buffer.write modifier.id
+          buffer.write_full modifier.amount
+          buffer.write modifier.operation.to_u32
+        end
+      end
+    end.to_slice
+  end
+
+  def callback(client)
+    if entity = client.dimension.entities[entity_id]?
+      entity.apply_attribute_snapshots(attribute_snapshots)
+    end
+    if entity_id == client.player.entity_id
+      client.player.apply_attribute_snapshots(attribute_snapshots)
+    end
+  end
+end

--- a/src/rosegold/world/attribute_snapshot.cr
+++ b/src/rosegold/world/attribute_snapshot.cr
@@ -1,0 +1,36 @@
+module Rosegold
+  struct AttributeModifier
+    getter id : String
+    getter amount : Float64
+    getter operation : UInt8
+
+    def initialize(@id, @amount, @operation)
+    end
+  end
+
+  struct AttributeSnapshot
+    SPRINTING_MODIFIER_ID = "minecraft:sprinting"
+
+    getter attribute_id : UInt32
+    getter base : Float64
+    getter modifiers : Array(AttributeModifier)
+
+    def initialize(@attribute_id, @base, @modifiers = [] of AttributeModifier)
+    end
+
+    def effective_value(excluding : Enumerable(String)? = nil) : Float64
+      additive = 0.0
+      multiply_base = 0.0
+      multiply_total = 1.0
+      modifiers.each do |modifier|
+        next if excluding && excluding.includes?(modifier.id)
+        case modifier.operation
+        when 0_u8 then additive += modifier.amount
+        when 1_u8 then multiply_base += modifier.amount
+        when 2_u8 then multiply_total *= (1.0 + modifier.amount)
+        end
+      end
+      (base + additive) * (1.0 + multiply_base) * multiply_total
+    end
+  end
+end

--- a/src/rosegold/world/entity.cr
+++ b/src/rosegold/world/entity.cr
@@ -1,5 +1,6 @@
 require "../versions"
 require "minecraft-data"
+require "./attribute_snapshot"
 
 class Rosegold::Entity
   alias Metadata = Minecraft::Data::EntityMetadata
@@ -8,6 +9,13 @@ class Rosegold::Entity
   # parsed and memoized per protocol on first use.
   @@metadata_cache = {} of UInt32 => Array(Metadata)
   @@metadata_mutex = Mutex.new
+
+  # A decoded entity-metadata value; member types are exactly what the
+  # SetEntityData serializer readers return.
+  alias TrackedValue = Bool | UInt8 | UInt32 | UInt64 | Float32 | String |
+                       Rosegold::TextComponent | Rosegold::Slot | Rosegold::Vec3i | UUID |
+                       Minecraft::NBT::Tag | Tuple(Float32, Float32, Float32) | Array(UInt32) |
+                       Tuple(String, Rosegold::Vec3i) | Array(Float32) | Bytes | Nil
 
   def self.metadata_for_protocol : Array(Metadata)
     protocol = Client.protocol_version
@@ -43,9 +51,54 @@ class Rosegold::Entity
     passenger_ids : Array(UInt32) = [] of UInt32,
     effects : Array(EntityEffect) = [] of EntityEffect
 
+  property attributes : Hash(UInt32, AttributeSnapshot) = Hash(UInt32, AttributeSnapshot).new
+
+  # SetEntityData tracked values, keyed by metadata index. Partial updates merge.
+  property tracked_data : Hash(UInt8, TrackedValue) = Hash(UInt8, TrackedValue).new
+
+  def entity_flags : UInt8
+    tracked_data[0_u8]?.as?(UInt8) || 0_u8
+  end
+
+  def on_fire?
+    (entity_flags & 0x01) != 0
+  end
+
+  def crouching?
+    (entity_flags & 0x02) != 0
+  end
+
+  def sprinting?
+    (entity_flags & 0x08) != 0
+  end
+
+  def invisible?
+    (entity_flags & 0x20) != 0
+  end
+
+  def glowing?
+    (entity_flags & 0x40) != 0
+  end
+
+  def custom_name : Rosegold::TextComponent?
+    tracked_data[2_u8]?.as?(Rosegold::TextComponent)
+  end
+
+  def pose : UInt32?
+    tracked_data[6_u8]?.as?(UInt32)
+  end
+
+  def item_stack : Rosegold::Slot?
+    tracked_data[8_u8]?.as?(Rosegold::Slot)
+  end
+
   property? \
     on_ground : Bool = true,
     living : Bool = false
+
+  def apply_attribute_snapshots(snapshots : Array(AttributeSnapshot)) : Nil
+    snapshots.each { |snapshot| attributes[snapshot.attribute_id] = snapshot }
+  end
 
   # Matches vanilla MC's Entity.isPickable() = false. Default is pickable; only these are excluded.
   NON_PICKABLE_ENTITIES = Set{

--- a/src/rosegold/world/entity_metadata.cr
+++ b/src/rosegold/world/entity_metadata.cr
@@ -1,0 +1,144 @@
+require "../versions"
+
+# Entity metadata serializer type-id → symbol tables, per protocol, derived
+# from each version's decompiled EntityDataSerializers registration order.
+# The wire never length-frames a value, so an unknown serializer id (or one we
+# cannot decode) must raise rather than guess a width.
+module Rosegold::EntityMetadata
+  SHARED = {
+     0_u32 => :byte,
+     1_u32 => :varint,
+     2_u32 => :long,
+     3_u32 => :float,
+     4_u32 => :string,
+     5_u32 => :text_component,
+     6_u32 => :opt_text_component,
+     7_u32 => :slot,
+     8_u32 => :boolean,
+     9_u32 => :rotations,
+    10_u32 => :block_pos,
+    11_u32 => :opt_block_pos,
+    12_u32 => :direction,
+    13_u32 => :opt_uuid,
+    14_u32 => :block_state,
+    15_u32 => :opt_block_state,
+  }
+
+  PROTOCOL_772 = SHARED.merge({
+    16_u32 => :nbt,
+    17_u32 => :particle,
+    18_u32 => :particles,
+    19_u32 => :villager_data,
+    20_u32 => :opt_varint,
+    21_u32 => :pose,
+    22_u32 => :cat_variant,
+    23_u32 => :cow_variant,
+    24_u32 => :wolf_variant,
+    25_u32 => :wolf_sound_variant,
+    26_u32 => :frog_variant,
+    27_u32 => :pig_variant,
+    28_u32 => :chicken_variant,
+    29_u32 => :opt_global_pos,
+    30_u32 => :painting_variant,
+    31_u32 => :sniffer_state,
+    32_u32 => :armadillo_state,
+    33_u32 => :vector3,
+    34_u32 => :quaternion,
+  })
+
+  PROTOCOL_773 = SHARED.merge({
+    16_u32 => :particle,
+    17_u32 => :particles,
+    18_u32 => :villager_data,
+    19_u32 => :opt_varint,
+    20_u32 => :pose,
+    21_u32 => :cat_variant,
+    22_u32 => :cow_variant,
+    23_u32 => :wolf_variant,
+    24_u32 => :wolf_sound_variant,
+    25_u32 => :frog_variant,
+    26_u32 => :pig_variant,
+    27_u32 => :chicken_variant,
+    28_u32 => :opt_global_pos,
+    29_u32 => :painting_variant,
+    30_u32 => :sniffer_state,
+    31_u32 => :armadillo_state,
+    32_u32 => :copper_golem_state,
+    33_u32 => :weathering_copper_state,
+    34_u32 => :vector3,
+    35_u32 => :quaternion,
+    36_u32 => :resolvable_profile,
+  })
+
+  # 1.21.11 inserts zombie_nautilus_variant after chicken_variant and appends
+  # humanoid_arm; it is NOT identical to 1.21.9.
+  PROTOCOL_774 = SHARED.merge({
+    16_u32 => :particle,
+    17_u32 => :particles,
+    18_u32 => :villager_data,
+    19_u32 => :opt_varint,
+    20_u32 => :pose,
+    21_u32 => :cat_variant,
+    22_u32 => :cow_variant,
+    23_u32 => :wolf_variant,
+    24_u32 => :wolf_sound_variant,
+    25_u32 => :frog_variant,
+    26_u32 => :pig_variant,
+    27_u32 => :chicken_variant,
+    28_u32 => :zombie_nautilus_variant,
+    29_u32 => :opt_global_pos,
+    30_u32 => :painting_variant,
+    31_u32 => :sniffer_state,
+    32_u32 => :armadillo_state,
+    33_u32 => :copper_golem_state,
+    34_u32 => :weathering_copper_state,
+    35_u32 => :vector3,
+    36_u32 => :quaternion,
+    37_u32 => :resolvable_profile,
+    38_u32 => :humanoid_arm,
+  })
+
+  PROTOCOL_775 = SHARED.merge({
+    16_u32 => :particle,
+    17_u32 => :particles,
+    18_u32 => :villager_data,
+    19_u32 => :opt_varint,
+    20_u32 => :pose,
+    21_u32 => :cat_variant,
+    22_u32 => :cat_sound_variant,
+    23_u32 => :cow_variant,
+    24_u32 => :cow_sound_variant,
+    25_u32 => :wolf_variant,
+    26_u32 => :wolf_sound_variant,
+    27_u32 => :frog_variant,
+    28_u32 => :pig_variant,
+    29_u32 => :pig_sound_variant,
+    30_u32 => :chicken_variant,
+    31_u32 => :chicken_sound_variant,
+    32_u32 => :zombie_nautilus_variant,
+    33_u32 => :opt_global_pos,
+    34_u32 => :painting_variant,
+    35_u32 => :sniffer_state,
+    36_u32 => :armadillo_state,
+    37_u32 => :copper_golem_state,
+    38_u32 => :weathering_copper_state,
+    39_u32 => :vector3,
+    40_u32 => :quaternion,
+    41_u32 => :resolvable_profile,
+    42_u32 => :humanoid_arm,
+  })
+
+  PROTOCOL_776 = PROTOCOL_775
+
+  PROTOCOL_MAP = {% begin %}{
+    {% for proto in Rosegold::ENABLED_PROTOCOLS.keys.sort %}
+      {{proto}}_u32 => PROTOCOL_{{proto}},
+    {% end %}
+  }{% end %}
+
+  def self.serializer_for(type_id : UInt32, protocol_version : UInt32) : Symbol?
+    mapping = PROTOCOL_MAP[protocol_version]? ||
+              {% begin %}PROTOCOL_{{Rosegold::ENABLED_PROTOCOLS.keys.sort.last}}{% end %}
+    mapping[type_id]?
+  end
+end

--- a/src/rosegold/world/player.cr
+++ b/src/rosegold/world/player.cr
@@ -1,7 +1,18 @@
 require "./look"
 require "./vec3"
+require "./attribute_snapshot"
 
 class Rosegold::Player
+  # 26.2 adds four attributes before movement_speed, shifting its registry id.
+  MOVEMENT_SPEED_ATTRIBUTE_IDS = {
+    772_u32 => 22_u32,
+    773_u32 => 22_u32,
+    774_u32 => 22_u32,
+    775_u32 => 22_u32,
+    776_u32 => 26_u32,
+  }
+  SPRINT_EXCLUDED_MODIFIER_IDS = Set{Rosegold::AttributeSnapshot::SPRINTING_MODIFIER_ID}
+
   DEFAULT_AABB  = AABBf.new -0.3, 0.0, -0.3, 0.3, 1.8, 0.3
   SNEAKING_AABB = AABBf.new -0.3, 0.0, -0.3, 0.3, 1.5, 0.3
   CRAWLING_AABB = AABBf.new -0.3, 0.0, -0.3, 0.3, 0.625, 0.3
@@ -31,6 +42,7 @@ class Rosegold::Player
     effects : Array(EntityEffect) = [] of EntityEffect,
     flying_speed : Float32 = 0.05_f32,
     field_of_view_modifier : Float32 = 0.1_f32
+  property attributes : Hash(UInt32, AttributeSnapshot) = Hash(UInt32, AttributeSnapshot).new
   property fall_distance : Float64 = 0.0
   property? \
     on_ground : Bool = false,
@@ -100,6 +112,29 @@ class Rosegold::Player
 
   def levitation_level : Int32
     effects.find { |e| e.effect == EntityEffect::Effect::Levitation }.try { |e| e.amplifier.to_i32 + 1 } || 0
+  end
+
+  def apply_attribute_snapshots(snapshots : Array(AttributeSnapshot)) : Nil
+    snapshots.each { |snapshot| attributes[snapshot.attribute_id] = snapshot }
+  end
+
+  def clear_attributes : Nil
+    attributes.clear
+  end
+
+  def movement_speed_attribute : AttributeSnapshot?
+    id = MOVEMENT_SPEED_ATTRIBUTE_IDS[Rosegold::Client.protocol_version]?
+    id ? attributes[id]? : nil
+  end
+
+  # Synced attribute already folds in Speed/Slowness; sprint is excluded here because
+  # physics applies SPRINT_MULTIPLIER itself. Effect formula is the no-attribute fallback.
+  def ground_movement_speed(base_movement_speed : Float64) : Float64
+    if attribute = movement_speed_attribute
+      Math.max(0.0, attribute.effective_value(excluding: SPRINT_EXCLUDED_MODIFIER_IDS))
+    else
+      Math.max(0.0, base_movement_speed * (1.0 + 0.2 * speed_level) * (1.0 - 0.15 * slowness_level))
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

Extract entity-state handling from #347 onto current main.

- Decode entity metadata and merge partial updates into tracked state.
- Apply teleport position, rotation, and velocity updates, including `ROTATE_DELTA` from the vanilla 26.1 implementation.
- Track server attributes and use the synced movement speed without counting sprint twice.
- Clear cached player attributes on fresh login or a respawn that does not preserve them.

The 26.2 movement-speed registry shift has a regression test. Unknown teleport flags are rejected rather than silently misapplied. Particle and resolvable-profile metadata serializers still fall back to raw packets; this is not a complete metadata decoder.

## Validation

53 focused specs pass. Full and all five slim no-codegen builds, formatting, and diff checks pass. Teleport rotation semantics were checked against the local 26.1 decompiled source.

Exact 26.2 source and live entity behavior remain unverified.
