### PR TITLE
Support merchant container data

### DIFF
--- a/spec/packets/clientbound/container_set_data_spec.cr
+++ b/spec/packets/clientbound/container_set_data_spec.cr
@@ -1,0 +1,106 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::ContainerSetData do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "uses correct packet ID for protocol 772" do
+    expect(Rosegold::Clientbound::ContainerSetData[772_u32]).to eq(0x13_u32)
+  end
+
+  it "uses correct packet ID for protocol 773" do
+    expect(Rosegold::Clientbound::ContainerSetData[773_u32]).to eq(0x13_u32)
+  end
+
+  it "uses correct packet ID for protocol 774" do
+    expect(Rosegold::Clientbound::ContainerSetData[774_u32]).to eq(0x13_u32)
+  end
+
+  it "uses correct packet ID for protocol 775" do
+    expect(Rosegold::Clientbound::ContainerSetData[775_u32]).to eq(0x13_u32)
+  end
+
+  it "uses correct packet ID for protocol 776" do
+    expect(Rosegold::Clientbound::ContainerSetData[776_u32]).to eq(0x13_u32)
+  end
+
+  it "supports all five protocols" do
+    [772_u32, 773_u32, 774_u32, 775_u32, 776_u32].each do |protocol|
+      expect(Rosegold::Clientbound::ContainerSetData.supports_protocol?(protocol)).to be_true
+    end
+    expect(Rosegold::Clientbound::ContainerSetData.supports_protocol?(999_u32)).to be_false
+  end
+
+  it "belongs to PLAY state" do
+    expect(Rosegold::Clientbound::ContainerSetData.state).to eq(Rosegold::ProtocolState::PLAY)
+  end
+
+  it "is properly registered in PLAY state" do
+    play_state = Rosegold::ProtocolState::PLAY
+    expect(play_state.get_clientbound_packet(0x13_u8, 772_u32)).to eq(Rosegold::Clientbound::ContainerSetData)
+  end
+
+  describe "packet parsing" do
+    it "reads container_id, property, and value" do
+      io = Minecraft::IO::Memory.new
+      io.write 2_u32        # container_id (VarInt)
+      io.write_full 14_i16  # property (Short)
+      io.write_full 200_i16 # value (Short)
+      io.pos = 0
+
+      packet = Rosegold::Clientbound::ContainerSetData.read(io)
+
+      expect(packet.container_id).to eq(2_u32)
+      expect(packet.property_id).to eq(14_i16)
+      expect(packet.value).to eq(200_i16)
+    end
+
+    it "reads negative values" do
+      io = Minecraft::IO::Memory.new
+      io.write 0_u32
+      io.write_full 0_i16
+      io.write_full(-1_i16)
+      io.pos = 0
+
+      packet = Rosegold::Clientbound::ContainerSetData.read(io)
+
+      expect(packet.value).to eq(-1_i16)
+    end
+  end
+
+  describe "round-trip serialization" do
+    it "can write and read a container property update" do
+      original_packet = Rosegold::Clientbound::ContainerSetData.new(3_u32, 15_i16, 90_i16)
+
+      packet_bytes = original_packet.write
+      io = Minecraft::IO::Memory.new(packet_bytes)
+      io.read_byte # skip packet ID
+
+      read_packet = Rosegold::Clientbound::ContainerSetData.read(io)
+
+      expect(read_packet.container_id).to eq(3_u32)
+      expect(read_packet.property_id).to eq(15_i16)
+      expect(read_packet.value).to eq(90_i16)
+    end
+  end
+
+  describe "callback behavior" do
+    let(client) { Rosegold::Client.new("localhost", 25565, offline: {uuid: "00000000-0000-0000-0000-000000000000", username: "tester"}) }
+
+    it "stores the property on the container menu when the container id matches" do
+      packet = Rosegold::Clientbound::ContainerSetData.new(client.container_menu.id.to_u32, 0_i16, 42_i16)
+
+      packet.callback(client)
+
+      expect(client.container_menu.properties[0_i16]).to eq(42_i16)
+    end
+
+    it "drops the update when the container id does not match" do
+      mismatched_id = client.container_menu.id.to_u32 + 1_u32
+      packet = Rosegold::Clientbound::ContainerSetData.new(mismatched_id, 0_i16, 42_i16)
+
+      packet.callback(client)
+
+      expect(client.container_menu.properties.has_key?(0_i16)).to be_false
+    end
+  end
+end

--- a/spec/packets/clientbound/merchant_offers_spec.cr
+++ b/spec/packets/clientbound/merchant_offers_spec.cr
@@ -1,0 +1,206 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Clientbound::MerchantOffers do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "uses correct packet ID for protocol 772" do
+    expect(Rosegold::Clientbound::MerchantOffers[772_u32]).to eq(0x2D_u32)
+  end
+
+  it "uses correct packet ID for protocol 773" do
+    expect(Rosegold::Clientbound::MerchantOffers[773_u32]).to eq(0x32_u32)
+  end
+
+  it "uses correct packet ID for protocol 774" do
+    expect(Rosegold::Clientbound::MerchantOffers[774_u32]).to eq(0x32_u32)
+  end
+
+  it "uses correct packet ID for protocol 775" do
+    expect(Rosegold::Clientbound::MerchantOffers[775_u32]).to eq(0x34_u32)
+  end
+
+  it "uses correct packet ID for protocol 776" do
+    expect(Rosegold::Clientbound::MerchantOffers[776_u32]).to eq(0x34_u32)
+  end
+
+  it "supports all five protocols" do
+    [772_u32, 773_u32, 774_u32, 775_u32, 776_u32].each do |protocol|
+      expect(Rosegold::Clientbound::MerchantOffers.supports_protocol?(protocol)).to be_true
+    end
+    expect(Rosegold::Clientbound::MerchantOffers.supports_protocol?(999_u32)).to be_false
+  end
+
+  it "belongs to PLAY state" do
+    expect(Rosegold::Clientbound::MerchantOffers.state).to eq(Rosegold::ProtocolState::PLAY)
+  end
+
+  it "is properly registered in PLAY state" do
+    play_state = Rosegold::ProtocolState::PLAY
+    expect(play_state.get_clientbound_packet(0x2D_u8, 772_u32)).to eq(Rosegold::Clientbound::MerchantOffers)
+  end
+
+  describe "packet parsing" do
+    it "parses every field of a two-offer fixture" do
+      Rosegold::Client.protocol_version = 772_u32
+      max_stack_size_id = Rosegold::DataComponentTypes.id_for("max_stack_size", 772_u32) || raise "max_stack_size component id missing"
+
+      io = Minecraft::IO::Memory.new
+      io.write 5_u32 # container_id
+      io.write 2_u32 # trade count
+
+      # Offer 1: base_cost_a carries a component, cost_b present.
+      io.write 10_u32 # base_cost_a item_id
+      io.write 2_u32  # base_cost_a count
+      io.write 1_u32  # base_cost_a component count
+      io.write max_stack_size_id
+      io.write 64_u32        # MaxStackSize payload
+      io.write 1_u32         # result count
+      io.write 20_u32        # result item_id
+      io.write 0_u32         # result components_to_add
+      io.write 0_u32         # result components_to_remove
+      io.write true          # cost_b present
+      io.write 30_u32        # cost_b item_id
+      io.write 1_u32         # cost_b count
+      io.write 0_u32         # cost_b component count
+      io.write false         # out_of_stock
+      io.write_full 3_i32    # uses
+      io.write_full 12_i32   # max_uses
+      io.write_full 5_i32    # xp
+      io.write_full(-1_i32)  # special_price_diff
+      io.write_full 0.05_f32 # price_multiplier
+      io.write_full 0_i32    # demand
+
+      # Offer 2: bare base cost, no cost_b, no components.
+      io.write 40_u32 # base_cost_a item_id
+      io.write 1_u32  # base_cost_a count
+      io.write 0_u32  # base_cost_a component count
+      io.write 1_u32  # result count
+      io.write 50_u32 # result item_id
+      io.write 0_u32
+      io.write 0_u32
+      io.write false      # cost_b absent
+      io.write true       # out_of_stock
+      io.write_full 0_i32 # uses
+      io.write_full 7_i32 # max_uses
+      io.write_full 2_i32 # xp
+      io.write_full 0_i32 # special_price_diff
+      io.write_full 1.0_f32
+      io.write_full 4_i32 # demand
+
+      io.write 3_u32   # villager_level
+      io.write 150_u32 # villager_xp
+      io.write true    # show_progress
+      io.write false   # can_restock
+      io.pos = 0
+
+      packet = Rosegold::Clientbound::MerchantOffers.read(io)
+
+      expect(packet.container_id).to eq(5_u32)
+      expect(packet.trades.size).to eq(2)
+      expect(packet.villager_level).to eq(3_u32)
+      expect(packet.villager_xp).to eq(150_u32)
+      expect(packet.show_progress?).to be_true
+      expect(packet.can_restock?).to be_false
+
+      first = packet.trades[0]
+      expect(first.base_cost_a.item_id).to eq(10_u32)
+      expect(first.base_cost_a.count).to eq(2_u32)
+      expect(first.base_cost_a.components.size).to eq(1)
+      component_type, component = first.base_cost_a.components[0]
+      expect(component_type).to eq(max_stack_size_id)
+      expect(component).to be_a(Rosegold::DataComponents::MaxStackSize)
+      expect(component.as(Rosegold::DataComponents::MaxStackSize).value).to eq(64_u32)
+      expect(first.result.item_id_int).to eq(20_u32)
+      expect(first.cost_b).not_to be_nil
+      expect(first.cost_b.try &.item_id).to eq(30_u32)
+      expect(first.out_of_stock?).to be_false
+      expect(first.uses).to eq(3)
+      expect(first.max_uses).to eq(12)
+      expect(first.xp).to eq(5)
+      expect(first.special_price_diff).to eq(-1)
+      expect(first.price_multiplier).to eq(0.05_f32)
+      expect(first.demand).to eq(0)
+
+      second = packet.trades[1]
+      expect(second.base_cost_a.item_id).to eq(40_u32)
+      expect(second.base_cost_a.components.size).to eq(0)
+      expect(second.cost_b).to be_nil
+      expect(second.out_of_stock?).to be_true
+      expect(second.max_uses).to eq(7)
+      expect(second.demand).to eq(4)
+    end
+  end
+
+  describe "round-trip serialization" do
+    it "preserves every field including a component-bearing ItemCost" do
+      Rosegold::Client.protocol_version = 772_u32
+      max_stack_size_id = Rosegold::DataComponentTypes.id_for("max_stack_size", 772_u32) || raise "max_stack_size component id missing"
+
+      base_cost_a = Rosegold::Clientbound::MerchantOffers::ItemCost.new(
+        10_u32, 2_u32, [{max_stack_size_id, Rosegold::DataComponents::MaxStackSize.new(64_u32).as(Rosegold::DataComponent)}])
+      cost_b = Rosegold::Clientbound::MerchantOffers::ItemCost.new(30_u32, 1_u32)
+      offer1 = Rosegold::Clientbound::MerchantOffers::MerchantOffer.new(
+        base_cost_a, Rosegold::Slot.new(1_u32, 20_u32), cost_b, false,
+        3, 12, 5, -1, 0.05_f32, 0)
+      offer2 = Rosegold::Clientbound::MerchantOffers::MerchantOffer.new(
+        Rosegold::Clientbound::MerchantOffers::ItemCost.new(40_u32, 1_u32),
+        Rosegold::Slot.new(1_u32, 50_u32), nil, true,
+        0, 7, 2, 0, 1.0_f32, 4)
+
+      original = Rosegold::Clientbound::MerchantOffers.new(5_u32, [offer1, offer2], 3_u32, 150_u32, true, false)
+
+      io = Minecraft::IO::Memory.new(original.write)
+      io.read_byte # skip packet ID
+
+      read = Rosegold::Clientbound::MerchantOffers.read(io)
+
+      expect(read.container_id).to eq(5_u32)
+      expect(read.trades.size).to eq(2)
+      expect(read.trades[0].base_cost_a.components.size).to eq(1)
+      expect(read.trades[0].base_cost_a.components[0][0]).to eq(max_stack_size_id)
+      expect(read.trades[0].cost_b.try &.item_id).to eq(30_u32)
+      expect(read.trades[0].price_multiplier).to eq(0.05_f32)
+      expect(read.trades[0].special_price_diff).to eq(-1)
+      expect(read.trades[1].cost_b).to be_nil
+      expect(read.trades[1].out_of_stock?).to be_true
+      expect(read.villager_xp).to eq(150_u32)
+      expect(read.show_progress?).to be_true
+    end
+  end
+
+  describe "callback behavior" do
+    let(client) { Rosegold::Client.new("localhost", 25565, offline: {uuid: "00000000-0000-0000-0000-000000000000", username: "tester"}) }
+
+    it "stores offers and metadata on a matching MerchantMenu" do
+      menu = Rosegold::MerchantMenu.new(client, 7_u8, Rosegold::Chat.new("Trader"))
+      client.container_menu = menu
+
+      offer = Rosegold::Clientbound::MerchantOffers::MerchantOffer.new(
+        Rosegold::Clientbound::MerchantOffers::ItemCost.new(1_u32, 1_u32),
+        Rosegold::Slot.new(1_u32, 2_u32), nil, false, 0, 5, 1, 0, 1.0_f32, 0)
+      packet = Rosegold::Clientbound::MerchantOffers.new(7_u32, [offer], 2_u32, 40_u32, true, true)
+
+      packet.callback(client)
+
+      expect(menu.trades.size).to eq(1)
+      expect(menu.villager_level).to eq(2_u32)
+      expect(menu.villager_xp).to eq(40_u32)
+      expect(menu.show_progress?).to be_true
+      expect(menu.can_restock?).to be_true
+    end
+
+    it "ignores offers when the container id does not match" do
+      menu = Rosegold::MerchantMenu.new(client, 7_u8, Rosegold::Chat.new("Trader"))
+      client.container_menu = menu
+
+      offer = Rosegold::Clientbound::MerchantOffers::MerchantOffer.new(
+        Rosegold::Clientbound::MerchantOffers::ItemCost.new(1_u32, 1_u32),
+        Rosegold::Slot.new(1_u32, 2_u32), nil, false, 0, 5, 1, 0, 1.0_f32, 0)
+      packet = Rosegold::Clientbound::MerchantOffers.new(99_u32, [offer], 2_u32, 40_u32, true, true)
+
+      packet.callback(client)
+
+      expect(menu.trades.size).to eq(0)
+    end
+  end
+end

--- a/spec/packets/serverbound/select_trade_spec.cr
+++ b/spec/packets/serverbound/select_trade_spec.cr
@@ -1,0 +1,52 @@
+require "../../spec_helper"
+
+Spectator.describe Rosegold::Serverbound::SelectTrade do
+  after_each { Rosegold::Client.reset_protocol_version! }
+
+  it "uses correct packet ID for protocol 772" do
+    expect(Rosegold::Serverbound::SelectTrade[772_u32]).to eq(0x32_u32)
+  end
+
+  it "uses correct packet ID for protocol 773" do
+    expect(Rosegold::Serverbound::SelectTrade[773_u32]).to eq(0x32_u32)
+  end
+
+  it "uses correct packet ID for protocol 774" do
+    expect(Rosegold::Serverbound::SelectTrade[774_u32]).to eq(0x32_u32)
+  end
+
+  it "uses correct packet ID for protocol 775" do
+    expect(Rosegold::Serverbound::SelectTrade[775_u32]).to eq(0x33_u32)
+  end
+
+  it "uses correct packet ID for protocol 776" do
+    expect(Rosegold::Serverbound::SelectTrade[776_u32]).to eq(0x33_u32)
+  end
+
+  it "supports all five protocols" do
+    [772_u32, 773_u32, 774_u32, 775_u32, 776_u32].each do |protocol|
+      expect(Rosegold::Serverbound::SelectTrade.supports_protocol?(protocol)).to be_true
+    end
+    expect(Rosegold::Serverbound::SelectTrade.supports_protocol?(999_u32)).to be_false
+  end
+
+  describe "round-trip serialization" do
+    it "writes the selected trade index as a VarInt after the packet id" do
+      Rosegold::Client.protocol_version = 772_u32
+
+      io = Minecraft::IO::Memory.new(Rosegold::Serverbound::SelectTrade.new(3).write)
+
+      expect(io.read_byte).to eq(0x32_u8)
+      expect(io.read_var_int).to eq(3_u32)
+    end
+
+    it "uses the shifted 0x33 id on protocol 775" do
+      Rosegold::Client.protocol_version = 775_u32
+
+      io = Minecraft::IO::Memory.new(Rosegold::Serverbound::SelectTrade.new(1).write)
+
+      expect(io.read_byte).to eq(0x33_u8)
+      expect(io.read_var_int).to eq(1_u32)
+    end
+  end
+end

--- a/src/rosegold/inventory/menu.cr
+++ b/src/rosegold/inventory/menu.cr
@@ -48,6 +48,7 @@ abstract class Rosegold::Menu
   abstract def player_inventory_start : Int32
 
   property state_id : UInt32 = 0
+  property properties = Hash(Int16, Int16).new
   @player_inventory : PlayerInventory
   @cursor : Rosegold::Slot = Rosegold::Slot.new
   @remote_slots : Array(RemoteSlot)

--- a/src/rosegold/inventory/menus/merchant_menu.cr
+++ b/src/rosegold/inventory/menus/merchant_menu.cr
@@ -2,8 +2,18 @@ require "../container_menu"
 
 # Villager/wandering trader menu — 3 slots: first_input(0), second_input(1), result(2).
 class Rosegold::MerchantMenu < Rosegold::ContainerMenu
+  property trades = [] of Rosegold::Clientbound::MerchantOffers::MerchantOffer
+  property villager_level : UInt32 = 0_u32
+  property villager_xp : UInt32 = 0_u32
+  property? show_progress : Bool = false
+  property? can_restock : Bool = false
+
   def initialize(@client : Client, @id : UInt8, @title : Chat)
     super(@client, @id, @title, 3)
+  end
+
+  def select_trade(index : Int32) : Nil
+    @client.send_packet!(Serverbound::SelectTrade.new(index))
   end
 
   def first_input : Rosegold::Slot

--- a/src/rosegold/packets/clientbound/container_set_data.cr
+++ b/src/rosegold/packets/clientbound/container_set_data.cr
@@ -1,0 +1,43 @@
+class Rosegold::Clientbound::ContainerSetData < Rosegold::Clientbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+  packet_ids({
+    772_u32 => 0x13_u32, # MC 1.21.8
+    773_u32 => 0x13_u32, # MC 1.21.9
+    774_u32 => 0x13_u32, # MC 1.21.11
+    775_u32 => 0x13_u32, # MC 26.1
+    776_u32 => 0x13_u32, # MC 26.2
+  })
+  class_getter state = ProtocolState::PLAY
+
+  property \
+    container_id : UInt32,
+    property_id : Int16,
+    value : Int16
+
+  def initialize(@container_id, @property_id, @value)
+  end
+
+  def self.read(packet)
+    container_id = packet.read_var_int
+    property_id = packet.read_short
+    value = packet.read_short
+    new container_id, property_id, value
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      buffer.write container_id
+      buffer.write_full property_id
+      buffer.write_full value
+    end.to_slice
+  end
+
+  def callback(client)
+    if client.container_menu.id == container_id
+      client.container_menu.properties[property_id] = value
+    else
+      Log.debug { "Received container property update for unknown or mismatched window. Ignoring. Packet container_id=#{container_id}, client container_id=#{client.container_menu.id}, property=#{property_id}, value=#{value}" }
+    end
+  end
+end

--- a/src/rosegold/packets/clientbound/merchant_offers.cr
+++ b/src/rosegold/packets/clientbound/merchant_offers.cr
@@ -1,0 +1,140 @@
+require "../packet"
+
+class Rosegold::Clientbound::MerchantOffers < Rosegold::Clientbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+  packet_ids({
+    772_u32 => 0x2D_u32, # MC 1.21.8
+    774_u32 => 0x32_u32, # MC 1.21.11
+    773_u32 => 0x32_u32, # MC 1.21.9
+    775_u32 => 0x34_u32, # MC 26.1
+    776_u32 => 0x34_u32, # MC 26.2
+  })
+  class_getter state = ProtocolState::PLAY
+
+  # A price stack for a trade: item id + count plus a DataComponentExactPredicate
+  # (a flat list of required components; no partial-predicate map).
+  class ItemCost
+    property item_id : UInt32
+    property count : UInt32
+    property components : Array({UInt32, Rosegold::DataComponent})
+
+    def initialize(@item_id, @count = 1_u32, @components = [] of {UInt32, Rosegold::DataComponent})
+    end
+
+    def self.read(io) : self
+      item_id = io.read_var_int
+      count = io.read_var_int
+      components = [] of {UInt32, Rosegold::DataComponent}
+      io.read_var_int.times do
+        component_type = io.read_var_int
+        components << {component_type, Rosegold::DataComponent.create_component(component_type, io)}
+      end
+      new(item_id, count, components)
+    end
+
+    def write(io) : Nil
+      io.write item_id
+      io.write count
+      io.write components.size
+      components.each do |component_type, component|
+        io.write component_type
+        component.write(io)
+      end
+    end
+  end
+
+  class MerchantOffer
+    property base_cost_a : ItemCost
+    property result : Rosegold::Slot
+    property cost_b : ItemCost?
+    property uses : Int32
+    property max_uses : Int32
+    property xp : Int32
+    property special_price_diff : Int32
+    property price_multiplier : Float32
+    property demand : Int32
+    property? out_of_stock : Bool
+
+    def initialize(@base_cost_a, @result, @cost_b, @out_of_stock,
+                   @uses, @max_uses, @xp, @special_price_diff,
+                   @price_multiplier, @demand)
+    end
+
+    def self.read(io) : self
+      base_cost_a = ItemCost.read(io)
+      result = Rosegold::Slot.read(io)
+      cost_b = io.read_bool ? ItemCost.read(io) : nil
+      out_of_stock = io.read_bool
+      uses = io.read_int
+      max_uses = io.read_int
+      xp = io.read_int
+      special_price_diff = io.read_int
+      price_multiplier = io.read_float
+      demand = io.read_int
+      new(base_cost_a, result, cost_b, out_of_stock,
+        uses, max_uses, xp, special_price_diff, price_multiplier, demand)
+    end
+
+    def write(io) : Nil
+      base_cost_a.write(io)
+      io.write result
+      if cost = cost_b
+        io.write true
+        cost.write(io)
+      else
+        io.write false
+      end
+      io.write out_of_stock?
+      io.write_full uses
+      io.write_full max_uses
+      io.write_full xp
+      io.write_full special_price_diff
+      io.write_full price_multiplier
+      io.write_full demand
+    end
+  end
+
+  property container_id : UInt32
+  property trades : Array(MerchantOffer)
+  property villager_level : UInt32
+  property villager_xp : UInt32
+  property? show_progress : Bool
+  property? can_restock : Bool
+
+  def initialize(@container_id, @trades, @villager_level, @villager_xp, @show_progress, @can_restock)
+  end
+
+  def self.read(packet)
+    container_id = packet.read_var_int
+    trades = Array(MerchantOffer).new(packet.read_var_int) { MerchantOffer.read(packet) }
+    villager_level = packet.read_var_int
+    villager_xp = packet.read_var_int
+    show_progress = packet.read_bool
+    can_restock = packet.read_bool
+    new(container_id, trades, villager_level, villager_xp, show_progress, can_restock)
+  end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      buffer.write container_id
+      buffer.write trades.size
+      trades.each(&.write(buffer))
+      buffer.write villager_level
+      buffer.write villager_xp
+      buffer.write show_progress?
+      buffer.write can_restock?
+    end.to_slice
+  end
+
+  def callback(client)
+    menu = client.container_menu
+    return unless menu.is_a?(Rosegold::MerchantMenu) && menu.id == container_id
+
+    menu.trades = trades
+    menu.villager_level = villager_level
+    menu.villager_xp = villager_xp
+    menu.show_progress = show_progress?
+    menu.can_restock = can_restock?
+  end
+end

--- a/src/rosegold/packets/serverbound/select_trade.cr
+++ b/src/rosegold/packets/serverbound/select_trade.cr
@@ -1,0 +1,23 @@
+require "../packet"
+
+class Rosegold::Serverbound::SelectTrade < Rosegold::Serverbound::Packet
+  include Rosegold::Packets::ProtocolMapping
+  packet_ids({
+    772_u32 => 0x32_u32, # MC 1.21.8
+    774_u32 => 0x32_u32, # MC 1.21.11
+    773_u32 => 0x32_u32, # MC 1.21.9
+    775_u32 => 0x33_u32, # MC 26.1
+    776_u32 => 0x33_u32, # MC 26.2
+  })
+
+  property selected_slot : Int32
+
+  def initialize(@selected_slot : Int32); end
+
+  def write : Bytes
+    Minecraft::IO::Memory.new.tap do |buffer|
+      buffer.write self.class.packet_id_for_protocol(Client.protocol_version)
+      buffer.write selected_slot
+    end.to_slice
+  end
+end


### PR DESCRIPTION
## Summary

Extract merchant and container-property handling from #347 onto current main.

- Track `ContainerSetData` values on the active menu.
- Decode merchant offers, item costs, and villager progress metadata.
- Expose offer data and `MerchantMenu#select_trade` without adding an automatic trading workflow.

## Validation

33 focused specs, full no-codegen build, formatting, and diff checks pass. Packet layouts were checked against the local 1.21.11 decompiled source. Live villager trading remains unverified.
